### PR TITLE
GPRT implementation via the generic ray tracing interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ if (XDG_ENABLE_EMBREE)
 endif()
 
 if (XDG_ENABLE_GPRT)
-  target_link_libraries(xdg gprt)
+  target_link_libraries(xdg $<BUILD_INTERFACE:gprt>)
 endif()
 
 # ===================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,12 @@ src/embree/ray_tracer.cpp
 )
 endif()
 
+if (XDG_ENABLE_GPRT)
+list(APPEND xdg_sources
+src/gprt/ray_tracer.cpp
+)
+endif()
+
 if (XDG_ENABLE_LIBMESH)
 list(APPEND xdg_sources
 src/libmesh/mesh_manager.cpp
@@ -191,12 +197,24 @@ if (XDG_ENABLE_LIBMESH)
   target_compile_definitions(xdg PUBLIC XDG_ENABLE_LIBMESH)
 endif()
 
+if (XDG_ENABLE_EMBREE)
+  target_compile_definitions(xdg PUBLIC XDG_ENABLE_EMBREE)
+endif()
+
+if (XDG_ENABLE_GPRT)
+  target_compile_definitions(xdg PUBLIC XDG_ENABLE_GPRT)
+endif()
+
 # ==========================
 # Link ray tracing libraries
 # ==========================
 
 if (XDG_ENABLE_EMBREE)
   target_link_libraries(xdg embree fmt::fmt)
+endif()
+
+if (XDG_ENABLE_GPRT)
+  target_link_libraries(xdg gprt)
 endif()
 
 # ===================

--- a/docs/methods/design_philosophy.rst
+++ b/docs/methods/design_philosophy.rst
@@ -3,16 +3,16 @@
 XDG Design Philosophy
 =====================
 
-A live updated UML diagram of the current XDG class hierarchy is shown below: 
+A live updated UML diagram of the current XDG class hierarchy is shown below:
 
 .. raw:: html
 
-<div style="max-width: 800px; margin: auto;">
-         <iframe 
-             src="https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=0#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload" 
-             width="100%" 
-             height="600" 
-             frameborder="0" 
+     <div style="max-width: 800px; margin: auto;">
+         <iframe
+             src="https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=0#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload"
+             width="100%"
+             height="600"
+             frameborder="0"
              style="border: 1px solid #ccc; border-radius: 6px;">
          </iframe>
      </div>

--- a/docs/methods/design_philosophy.rst
+++ b/docs/methods/design_philosophy.rst
@@ -7,15 +7,15 @@ A live updated UML diagram of the current XDG class hierarchy is shown below:
 
 .. raw:: html
 
-<div style="max-width: 800px; margin: auto;">
-         <iframe 
-             src="https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=0#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload" 
-             width="100%" 
-             height="600" 
-             frameborder="0" 
-             style="border: 1px solid #ccc; border-radius: 6px;">
-         </iframe>
-     </div>
+    <div style="max-width: 800px; margin: auto;">
+        <iframe 
+            src="https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=0#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload" 
+            width="100%" 
+            height="600" 
+            frameborder="0" 
+            style="border: 1px solid #ccc; border-radius: 6px;">
+        </iframe>
+    </div>
 
 
 The primary design goals of XDG are centered on the following:

--- a/docs/methods/design_philosophy.rst
+++ b/docs/methods/design_philosophy.rst
@@ -3,19 +3,6 @@
 XDG Design Philosophy
 =====================
 
-A live updated UML diagram of the current XDG class hierarchy is shown below:
-
-.. raw:: html
-
-     <div style="max-width: 800px; margin: auto;">
-         <iframe
-             src="https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=0#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload"
-             width="100%"
-             height="600"
-             frameborder="0"
-             style="border: 1px solid #ccc; border-radius: 6px;">
-         </iframe>
-     </div>
 
 
 The primary design goals of XDG are centered on the following:
@@ -40,3 +27,17 @@ The primary design goals of XDG are centered on the following:
   allows for the use of multiple ray tracing libraries without changing the
   core XDG codebase. This is important for one of XDG's primary goals: to
   support ray tracing on both CPUs and GPUs in a single binary.
+
+A live updated UML diagram of the current XDG class hierarchy is shown below:
+
+.. raw:: html
+
+     <div style="max-width: 800px; margin: auto;">
+         <iframe
+             src="https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=0#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload"
+             width="100%"
+             height="600"
+             frameborder="0"
+             style="border: 1px solid #ccc; border-radius: 6px;">
+         </iframe>
+     </div>

--- a/docs/methods/design_philosophy.rst
+++ b/docs/methods/design_philosophy.rst
@@ -8,7 +8,7 @@ A UML diagram of the current XDG class hierarchy is shown below:
 .. raw:: html
 
     <iframe src="https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=0#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload"
-            width="800" height="600" frameborder="0"></iframe>
+            width="100%" height="600" frameborder="0" style="max-width: 100%; height: auto;"></iframe>
 
 The primary design goals of XDG are centered on the following:
 

--- a/docs/methods/design_philosophy.rst
+++ b/docs/methods/design_philosophy.rst
@@ -3,23 +3,20 @@
 XDG Design Philosophy
 =====================
 
-A UML diagram of the current XDG class hierarchy is shown below: 
+A live updated UML diagram of the current XDG class hierarchy is shown below: 
 
 .. raw:: html
 
-.. raw:: html
+<div style="max-width: 800px; margin: auto;">
+         <iframe 
+             src="https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=0#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload" 
+             width="100%" 
+             height="600" 
+             frameborder="0" 
+             style="border: 1px solid #ccc; border-radius: 6px;">
+         </iframe>
+     </div>
 
-    <div id="xdg-diagram-container"></div>
-    <script>
-      const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const darkMode = isDark ? 1 : 0;
-      const iframe = document.createElement('iframe');
-      iframe.src = `https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=${darkMode}#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload`;
-      iframe.width = "800";
-      iframe.height = "600";
-      iframe.frameBorder = "0";
-      document.getElementById('xdg-diagram-container').appendChild(iframe);
-    </script>
 
 The primary design goals of XDG are centered on the following:
 

--- a/docs/methods/design_philosophy.rst
+++ b/docs/methods/design_philosophy.rst
@@ -7,8 +7,19 @@ A UML diagram of the current XDG class hierarchy is shown below:
 
 .. raw:: html
 
-    <iframe src="https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=0#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload"
-            width="100%" height="600" frameborder="0" style="max-width: 100%; height: auto;"></iframe>
+.. raw:: html
+
+    <div id="xdg-diagram-container"></div>
+    <script>
+      const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const darkMode = isDark ? 1 : 0;
+      const iframe = document.createElement('iframe');
+      iframe.src = `https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=${darkMode}#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload`;
+      iframe.width = "800";
+      iframe.height = "600";
+      iframe.frameBorder = "0";
+      document.getElementById('xdg-diagram-container').appendChild(iframe);
+    </script>
 
 The primary design goals of XDG are centered on the following:
 

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -14,6 +14,7 @@
 #include "xdg/error.h"
 
 #include "gprt/gprt.h"
+#include "sharedCode.h"
 
 namespace xdg {
 

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -12,9 +12,8 @@
 #include "xdg/ray_tracing_interface.h"
 #include "xdg/ray.h"
 #include "xdg/error.h"
-
 #include "gprt/gprt.h"
-#include "sharedCode.h"
+
 
 namespace xdg {
 
@@ -23,7 +22,9 @@ class GPRTRayTracer : public RayTracer {
 public:
   GPRTRayTracer();
   ~GPRTRayTracer();
+  
   void init() override;
+//   void add_module(GPRTProgam device_code, std::string name);
   TreeID register_volume(const std::shared_ptr<MeshManager> mesh_manager, MeshID volume) override;
 
   // Query Methods
@@ -61,8 +62,9 @@ public:
   // GPRT members
   GPRTContext context_;
   std::vector<GPRTGeom> geometries_; //<! All geometries created by this ray tracer
-
-  // Mesh-to-Scene maps
+  //std::map<std::string,GPRTModule> device_codes_; //<! All device code modules associated with the GPRTContext
+  
+  // Mesh-to-Scene maps 
   std::map<MeshID, GPRTGeom> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
 
   // Internal GPRT Mappings

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -1,0 +1,79 @@
+#ifndef _XDG_GPRT_RAY_TRACING_INTERFACE_H
+#define _XDG_GPRT_RAY_TRACING_INTERFACE_H
+
+#include <memory>
+#include <vector>
+#include <unordered_map>
+
+#include "xdg/constants.h"
+#include "xdg/mesh_manager_interface.h"
+#include "xdg/primitive_ref.h"
+#include "xdg/geometry_data.h"
+#include "xdg/ray_tracing_interface.h"
+#include "xdg/ray.h"
+#include "xdg/error.h"
+
+#include "gprt/gprt.h"
+
+namespace xdg {
+
+class GPRTRayTracer : public RayTracer {
+  // constructors
+public:
+  GPRTRayTracer();
+  ~GPRTRayTracer();
+  void init() override;
+  TreeID register_volume(const std::shared_ptr<MeshManager> mesh_manager, MeshID volume) override;
+
+  // Query Methods
+  bool point_in_volume(TreeID scene,
+                      const Position& point,
+                      const Direction* direction = nullptr,
+                      const std::vector<MeshID>* exclude_primitives = nullptr) const override;
+
+
+  std::pair<double, MeshID> ray_fire(TreeID scene,
+                                     const Position& origin,
+                                     const Direction& direction,
+                                     const double dist_limit = INFTY,
+                                     HitOrientation orientation = HitOrientation::EXITING,
+                                     std::vector<MeshID>* const exclude_primitives = nullptr) override;
+
+  void closest(TreeID scene,
+               const Position& origin,
+               double& dist,
+               MeshID& triangle) override;
+
+  void closest(TreeID scene,
+               const Position& origin,
+               double& dist) override;
+
+  bool occluded(TreeID scene,
+                const Position& origin,
+                const Direction& direction,
+                double& dist) const override;
+
+  // Accessors
+  const std::shared_ptr<GeometryUserData>& geometry_data(MeshID surface) const override
+  { return user_data_map_.at(surface_to_geometry_map_.at(surface)); };
+
+  // GPRT members
+  GPRTContext context_;
+  std::vector<GPRTGeom> geometries_; //<! All geometries created by this ray tracer
+
+  // Mesh-to-Scene maps
+  std::map<MeshID, GPRTGeom> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
+
+  // Internal GPRT Mappings
+  std::unordered_map<GPRTGeom, std::shared_ptr<GeometryUserData>> user_data_map_;
+
+  std::unordered_map<TreeID, GPRTAccel> accel_to_scene_map_; // Map from XDG::TreeID to specific embree scene/tree
+
+  // storage
+  std::unordered_map<GPRTAccel, std::vector<PrimitiveRef>> primitive_ref_storage_;
+};
+
+} // namespace xdg
+
+
+#endif // include guard

--- a/include/xdg/gprt/sharedCode.h
+++ b/include/xdg/gprt/sharedCode.h
@@ -1,0 +1,120 @@
+#include "gprt/gprt.h"
+
+/* variables for the triangle mesh geometry */
+struct DPTriangleData
+{
+#ifdef GPRT_CPU_ONLY
+  typedef double3 vertex_type;
+#endif
+  /*! array/buffer of vertex indices */
+  uint32_t* index; // vec3f*
+  /*! array/buffer of vertex positions */
+  uint32_t* vertex; // float *
+  /*! array/buffer of AABBs */
+  uint32_t* aabbs;
+  /*! array/buffer of double precision rays */
+  uint32_t* dpRays;
+  /* ID of the surface (negative if triangle connecivity has been reversed)*/
+  int32_t id;
+  /*! acceleration data structure for the volume on the front face */
+  int32_t ff_vol;
+  /*! acceleration data structure for the volume on the back face */
+  int32_t bf_vol;
+  /*! frame buffer size */
+  int2 fbSize;
+  /*! volume on the forward (front) and reverse (back) side of the surface */
+  int2 vols;
+};
+
+struct SPTriangleData
+{
+#ifdef GPRT_CPU_ONLY
+  typedef float3 vertex_type;
+#endif
+  /*! array/buffer of vertex indices */
+  uint32_t* index; // vec3f*
+  /*! array/buffer of vertex positions */
+  uint32_t* vertex; // float *
+  /* ID of the surface (negative if triangle connecivity has been reversed)*/
+  int32_t id;
+  /*! acceleration data structure for the volume on the front face */
+  int32_t ff_vol;
+  /*! acceleration data structure for the volume on the back face */
+  int32_t bf_vol;
+  /*! volume on the forward and reverse side of the surface */
+  int2 vols;
+};
+
+struct RayGenData
+{
+  uint32_t* accumPtr;
+  uint32_t* fbPtr;
+  uint32_t* dpRays;
+
+  GPRTTexture guiTexture;
+
+  // a relative unit for delta tracking, similar to "dt"
+  float unit;
+  uint32_t frameID;
+  uint32_t numVolumes;
+  uint32_t maxVolID;
+  uint32_t graveyardID;
+  uint32_t complementID;
+  // colormap for visualization
+  GPRTTexture surfaceColormap;
+  GPRTTexture ddaColormap;
+  GPRTSampler colormapSampler;
+
+  int2 fbSize;
+
+  uint32_t moveOrigin;
+
+  GPRTAccel world;
+  uint32_t* partTrees; // GPRTAccel*
+
+  uint32_t* ddaGrid;
+  uint3 gridDims;
+
+  float3 aabbMin;
+  float3 aabbMax;
+
+  struct {
+    float3 pos;
+    float3 dir_00;
+    float3 dir_du;
+    float3 dir_dv;
+  } camera;
+};
+
+/* variables for the miss program */
+struct MissProgData
+{
+  float3  color0;
+  float3  color1;
+};
+
+#ifdef GPRT_DEVICE
+
+#define MAX_DEPTH 100
+
+#define EPSILON 2.2204460492503130808472633361816E-16
+#define FLT_EPSILON	1.19209290e-7F
+#define DBL_EPSILON	2.2204460492503131e-16
+
+float4 over(float4 a, float4 b) {
+  float4 result;
+  result.a = a.a + b.a * (1.f - a.a);
+  result.rgb = (a.rgb * a.a + b.rgb * b.a * (1.f - a.a)) / result.a;
+  return result;
+}
+
+struct [raypayload] Payload
+{
+  // .y = moving into that volume
+  int2 vol_ids       : read(caller) : write(miss, closesthit);
+  int surf_id        : read(caller) : write(closesthit);
+  float hitDistance  : read(caller) : write(closesthit);
+  int next_vol       : read(caller) : write(closesthit);
+};
+
+#endif

--- a/src/gprt/ray_tracer.cpp
+++ b/src/gprt/ray_tracer.cpp
@@ -1,0 +1,5 @@
+#include "xdg/gprt/ray_tracer.h"
+
+namespace xdg {
+
+} // namespace xdg

--- a/src/gprt/ray_tracer.cpp
+++ b/src/gprt/ray_tracer.cpp
@@ -1,5 +1,6 @@
 #include "xdg/gprt/ray_tracer.h"
 
+
 namespace xdg {
 
 } // namespace xdg

--- a/src/gprt/ray_tracer.cpp
+++ b/src/gprt/ray_tracer.cpp
@@ -3,4 +3,21 @@
 
 namespace xdg {
 
+GPRTRayTracer::GPRTRayTracer()
+{
+  context_ = gprtContextCreate();
+}
+
+GPRTRayTracer::~GPRTRayTracer()
+{
+  gprtContextDestroy(context_);
+}
+
+// void GPRTRayTracer::add_module(GPRTProgram device_code, std::string name)
+// {
+//   GPRTModule module = gprtModuleCreate(context_, device_code);
+//   device_codes_[name] = module;
+// }
+
+
 } // namespace xdg

--- a/tools/gprt/gprt_test.cpp
+++ b/tools/gprt/gprt_test.cpp
@@ -63,16 +63,18 @@ int main(int argc, char* argv[]) {
     exit(0);
   }
 
+  auto hdf_file = args.get<std::string>("filename");
+
   // Initialize XDG
   std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
   const auto& mm = xdg->mesh_manager();
-  mm->load_file(args.get<std::string>("filename"));
+  mm->load_file(hdf_file);
   mm->init();
   xdg->prepare_raytracer();
   
 
   // Create a rendering window
-  gprtRequestWindow(fbSize.x, fbSize.y, "GPRT Triangle XDG-Test");
+  gprtRequestWindow(fbSize.x, fbSize.y, hdf_file.c_str());
 
   // Initialize GPRT context and modules
   GPRTContext context = gprtContextCreate();


### PR DESCRIPTION
Started working on laying out the ground work for implementing a concrete ray tracer for GPRT which inherits the current ray tracing interface. 

There currently exists a CMake warning that gets thrown up:
```
CMake Error: install(EXPORT "xdg-targets" ...) includes target "xdg" which requires target "gprt" that is not in any export set.
-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```
 However the Makefile is still generated and I am still able to successfully compile XDG with no issues in spite of this warning.