### PR TITLE
An implementation of double precision ray tracing in the GPRTRayTracer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,8 +117,8 @@ list(APPEND xdg_sources
 src/gprt/ray_tracer.cpp
 )
 list(APPEND xdg_device_codes
-flt
-dbl
+flt_deviceCode
+dbl_deviceCode
 )
 
 endif()
@@ -221,21 +221,22 @@ if (XDG_ENABLE_EMBREE)
   target_link_libraries(xdg embree fmt::fmt)
 endif()
 
-if (XDG_ENABLE_GPRT)
-  target_link_libraries(xdg $<BUILD_INTERFACE:gprt>)
-
-  # Compile device code for single precision shaders
-  embed_devicecode(
-  OUTPUT_TARGET
-  flt_deviceCode
-  HEADERS
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/gprt/sharedCode.h
-  SOURCES
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/gprt/flt_deviceCode.slang
+# compile both single and double precision shaders for GPRT
+foreach(device_code ${xdg_device_codes})
+  if (XDG_ENABLE_GPRT)
+    target_link_libraries(xdg $<BUILD_INTERFACE:gprt>)
+    # Compile device code for single precision shaders
+    embed_devicecode(
+    OUTPUT_TARGET
+    ${device_code}
+    HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gprt/sharedCode.h
+    SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gprt/${device_code}.slang
   )
-
-  target_link_libraries(xdg flt_deviceCode)
-endif()
+  target_link_libraries(xdg ${device_code})
+  endif()
+endforeach()
 
 # ===================
 # Link mesh libraries
@@ -262,11 +263,16 @@ install(TARGETS xdg
   INCLUDES DESTINATION include
 )
 
-install(TARGETS flt_deviceCode
-  EXPORT xdg-targets
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
+# Install both single and double precision device code for GPRT
+foreach(device_code ${xdg_device_codes})
+  install(TARGETS ${device_code}
+    EXPORT xdg-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+endforeach()
+
+
 
 install(EXPORT xdg-targets
   FILE XDGTargets.cmake

--- a/include/xdg/constants.h
+++ b/include/xdg/constants.h
@@ -5,6 +5,23 @@
 #include <limits>
 #include <string>
 
+#include "math/VectorTypes.h"
+
+// extending the math namespace from GPRT/VectorTypes.h
+namespace math
+{
+  using double1 = vector<double, 1>;
+  using double2 = vector<double, 2>;
+  using double3 = vector<double, 3>;
+  using double4 = vector<double, 4>;
+}
+
+// Type aliases for convenience
+using double1 = math::double1;
+using double2 = math::double2;
+using double3 = math::double3; 
+using double4 = math::double4;
+
 namespace xdg {
 
 constexpr double INFTY {std::numeric_limits<double>::max()};
@@ -116,6 +133,11 @@ enum class SurfaceElementType {
 enum class VolumeElementType {
   TET = 0,
   HEX = 1,
+};
+
+enum class FloatingPointPrecision {
+  SINGLE = 0, // Single precision (float)
+  DOUBLE = 1  // Double precision (double)
 };
 
 } // namespace xdg

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -87,14 +87,15 @@ namespace xdg {
       GPRTModule module_; // device code module for single precision shaders
       // std::vector<GPRTGeom> geometries_; //<! All geometries created by this ray tracer
       GPRTAccel world_; 
-      GPRTRayGenOf<RayGenData> rayGenProgram_; //<! Ray generation program
-      GPRTRayGenOf<RayGenData> rayGenPointInVolProgram_;
+      GPRTRayGenOf<dblRayGenData> rayGenProgram_; //<! Ray generation program
+      GPRTRayGenOf<dblRayGenData> rayGenPointInVolProgram_;
       GPRTMissOf<void> missProgram_; //<! Miss program
       GPRTComputeOf<DPTriangleGeomData> aabbPopulationProgram_; //<! AABB population program for double precision rays
       GPRTBufferOf<uint32_t> frameBuffer_; //<! Framebuffer
       int2 fbSize; //<! Size of the framebuffer 
-      GPRTBufferOf<RayInput> rayInputBuffer_; //<! Ray buffer for ray generation
-      GPRTBufferOf<RayOutput> rayOutputBuffer_; //<! Ray output buffer for ray generation
+      GPRTBufferOf<dblRayInput> rayInputBuffer_; //<! Ray buffer for ray generation
+      GPRTBufferOf<dblRayOutput> rayOutputBuffer_; //<! Ray output buffer for ray generation
+      GPRTBufferOf<double4> dpRaysBuffer_; //<! Double precision ray buffer for ray generation
       GPRTBufferOf<int32_t> excludePrimitivesBuffer_; //<! Buffer for excluded primitives
       size_t numRays = 1; //<! Number of rays to be cast
       uint32_t numRayTypes_ = 2; // <! Number of ray types. Allows multiple shaders to be set to the same geometery

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -16,6 +16,7 @@
 #include "sharedCode.h"
 
 extern GPRTProgram flt_deviceCode;
+extern GPRTProgram dbl_deviceCode;
 
 namespace xdg {
 
@@ -27,6 +28,9 @@ namespace xdg {
       void set_geom_data(const std::shared_ptr<MeshManager> mesh_manager);
       void create_world_tlas();
   
+      TreeID register_triangle_geometry(const std::shared_ptr<MeshManager> mesh_manager, MeshID surface);
+      TreeID register_AABB_geometry(const std::shared_ptr<MeshManager> mesh_manager, MeshID surface);
+
       void init() override;
 
       // Setup the different shader programs for use with this ray tracer
@@ -76,6 +80,8 @@ namespace xdg {
       void render_mesh(const std::shared_ptr<MeshManager> mesh_manager);
 
     private:
+      FloatingPointPrecision precision_;
+
       GPRTContext context_;
       GPRTProgram deviceCode_; // device code for float precision shaders
       GPRTModule module_; // device code module for single precision shaders
@@ -84,6 +90,7 @@ namespace xdg {
       GPRTRayGenOf<RayGenData> rayGenProgram_; //<! Ray generation program
       GPRTRayGenOf<RayGenData> rayGenPointInVolProgram_;
       GPRTMissOf<void> missProgram_; //<! Miss program
+      GPRTComputeOf<DPTriangleGeomData> aabbPopulationProgram_; //<! AABB population program for double precision rays
       GPRTBufferOf<uint32_t> frameBuffer_; //<! Framebuffer
       int2 fbSize; //<! Size of the framebuffer 
       GPRTBufferOf<RayInput> rayInputBuffer_; //<! Ray buffer for ray generation
@@ -92,12 +99,13 @@ namespace xdg {
       size_t numRays = 1; //<! Number of rays to be cast
       uint32_t numRayTypes_ = 2; // <! Number of ray types. Allows multiple shaders to be set to the same geometery
       std::vector<gprt::Instance> globalBlasInstances_; //<! List of every BLAS instance stored in this ray tracer
-      GPRTGeomTypeOf<TrianglesGeomData> trianglesGeomType_; //<! Geometry type for triangles
+      GPRTGeomTypeOf<DPTriangleGeomData> trianglesGeomType_; //<! Geometry type for triangles
+
 
 
 
       // Mesh-to-Scene maps 
-      std::map<MeshID, GPRTGeomOf<TrianglesGeomData>> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
+      std::map<MeshID, GPRTGeomOf<DPTriangleGeomData>> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
 
       // Internal GPRT Mappings
       std::unordered_map<GPRTGeom, std::shared_ptr<GeometryUserData>> user_data_map_;

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -67,8 +67,11 @@ namespace xdg {
         return false;
       }
   
+      // const std::shared_ptr<GeometryUserData>& geometry_data(MeshID surface) const override
+      // { return user_data_map_.at(surface_to_geometry_map_.at(surface)); };
+
       const std::shared_ptr<GeometryUserData>& geometry_data(MeshID surface) const override
-      { return user_data_map_.at(surface_to_geometry_map_.at(surface)); };
+      { };
   
       void render_mesh(const std::shared_ptr<MeshManager> mesh_manager);
 
@@ -89,14 +92,16 @@ namespace xdg {
       size_t numRays = 1; //<! Number of rays to be cast
       uint32_t numRayTypes_ = 2; // <! Number of ray types. Allows multiple shaders to be set to the same geometery
       std::vector<gprt::Instance> globalBlasInstances_; //<! List of every BLAS instance stored in this ray tracer
+      GPRTGeomTypeOf<TrianglesGeomData> trianglesGeomType_; //<! Geometry type for triangles
 
 
 
       // Mesh-to-Scene maps 
-      std::map<MeshID, GPRTGeom> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
+      std::map<MeshID, GPRTGeomOf<TrianglesGeomData>> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
 
       // Internal GPRT Mappings
       std::unordered_map<GPRTGeom, std::shared_ptr<GeometryUserData>> user_data_map_;
+      std::unordered_map<MeshID, gprt::Instance> surface_to_instance_map_; //<! Map from mesh surface to GPRT instance
 
       std::unordered_map<TreeID, GPRTAccel> tree_to_vol_accel_map; // Map from XDG::TreeID to GPRTAccel for volume TLAS
 
@@ -104,6 +109,7 @@ namespace xdg {
       std::unordered_map<GPRTAccel, std::vector<PrimitiveRef>> primitive_ref_storage_; // Comes from sharedCode.h?
       std::vector<GPRTBufferOf<float3>> vertex_buffers; // <! vertex buffers for each geometry
       std::vector<GPRTBufferOf<uint3>> connectivity_buffers; // <! connectivity buffers for each geometry
+      std::vector<GPRTGeomOf<TrianglesGeomData>> allTrianglesGeom; //<! Triangle geometries for each surface
 
     };
 

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -54,13 +54,10 @@ namespace xdg {
       void closest(TreeID scene,
                   const Position& origin,
                   double& dist,
-                  MeshID& triangle) override {
-        // Find the closest triangle to the origin
-      }
-  
+                  MeshID& triangle) override {};
       void closest(TreeID scene,
                   const Position& origin,
-                  double& dist) override;
+                  double& dist) override {};
   
       bool occluded(TreeID scene,
                     const Position& origin,
@@ -73,7 +70,7 @@ namespace xdg {
       const std::shared_ptr<GeometryUserData>& geometry_data(MeshID surface) const override
       { return user_data_map_.at(surface_to_geometry_map_.at(surface)); };
   
-      void render_mesh();
+      void render_mesh(const std::shared_ptr<MeshManager> mesh_manager);
 
     private:
       GPRTContext context_;
@@ -92,6 +89,8 @@ namespace xdg {
       size_t numRays = 1; //<! Number of rays to be cast
       uint32_t numRayTypes_ = 2; // <! Number of ray types. Allows multiple shaders to be set to the same geometery
       std::vector<gprt::Instance> globalBlasInstances_; //<! List of every BLAS instance stored in this ray tracer
+
+
 
       // Mesh-to-Scene maps 
       std::map<MeshID, GPRTGeom> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -90,6 +90,7 @@ namespace xdg {
       GPRTBufferOf<RayOutput> rayOutputBuffer_; //<! Ray output buffer for ray generation
       GPRTBufferOf<int32_t> excludePrimitivesBuffer_; //<! Buffer for excluded primitives
       size_t numRays = 1; //<! Number of rays to be cast
+      uint32_t numRayTypes_ = 2; // <! Number of ray types. Allows multiple shaders to be set to the same geometery
       std::vector<gprt::Instance> globalBlasInstances_; //<! List of every BLAS instance stored in this ray tracer
 
       // Mesh-to-Scene maps 

--- a/include/xdg/gprt/sharedCode.h
+++ b/include/xdg/gprt/sharedCode.h
@@ -17,6 +17,8 @@ struct dblRayInput
 {
   double3 origin;
   double3 direction;
+  double tMin; // Minimum distance for ray intersection
+  double tMax; // Maximum distance for ray intersection
   int32_t* exclude_primitives; // Optional for excluding primitives
   uint32_t exclude_count;           // Number of excluded primitives
 };
@@ -52,7 +54,8 @@ struct DPTriangleGeomData {
   uint3 *index;  // index buffer
   double3 *normals; // normals buffer
   dblRayInput *ray; // double precision rays
-  uint id;       // surface id
+  dblRayOutput *out;
+  int2 vols;
   int forward_vol;
   int reverse_vol;
 };

--- a/include/xdg/gprt/sharedCode.h
+++ b/include/xdg/gprt/sharedCode.h
@@ -51,7 +51,7 @@ struct DPTriangleGeomData {
   float3 *aabbs; // AABB buffer 
   uint3 *index;  // index buffer
   double3 *normals; // normals buffer
-  double4 *dprays; // double precision rays
+  dblRayInput *ray; // double precision rays
   uint id;       // surface id
   int forward_vol;
   int reverse_vol;
@@ -62,6 +62,13 @@ struct RayGenData {
   SurfaceAccelerationStructure world;    // The top-level accel structure
   RayInput *ray;
   RayOutput *out;
+};
+
+struct dblRayGenData {
+  uint* frameBuffer;                     // Optional for debugging or visuals
+  SurfaceAccelerationStructure world;    // The top-level accel structure
+  dblRayInput *ray;
+  dblRayOutput *out;
 };
 
 struct RayFireData {

--- a/include/xdg/gprt/sharedCode.h
+++ b/include/xdg/gprt/sharedCode.h
@@ -61,7 +61,9 @@ struct MissProgData {
   shader binding table. (must be 128 bytes or less) */
 struct PushConstants {
   float time;
+  float3 scene_center;
   struct Camera {
+    float radius;
     float3 pos;
     float3 dir_00;
     float3 dir_du;

--- a/include/xdg/gprt/sharedCode.h
+++ b/include/xdg/gprt/sharedCode.h
@@ -23,8 +23,8 @@ struct TrianglesGeomData {
   uint3 *index;   // index buffer
   float3 *normals;
   uint id;        // surface id
-  int2 vols;      // parent volumes ids
-  int sense;      // surface sense
+  int forward_vol; 
+  int reverse_vol;
 };
 // /* variables for the triangle mesh geometry */
 // struct DPTriangleGeomData {

--- a/include/xdg/gprt/sharedCode.h
+++ b/include/xdg/gprt/sharedCode.h
@@ -2,6 +2,9 @@
 
 #define AA 3 // used for antialiasing
 
+using double3 = std::array<double, 3>;
+using double4 = std::array<double, 4>;
+
 /* Inputs for each ray */
 struct RayInput {
   float3 origin;

--- a/include/xdg/gprt/sharedCode.h
+++ b/include/xdg/gprt/sharedCode.h
@@ -1,9 +1,9 @@
 #include "gprt.h"
 
 #define AA 3 // used for antialiasing
-
-using double3 = std::array<double, 3>;
-using double4 = std::array<double, 4>;
+#define EPSILON 2.2204460492503130808472633361816E-16
+// #define FLT_EPSILON	1.19209290e-7F
+// #define DBL_EPSILON	2.2204460492503131e-16
 
 /* Inputs for each ray */
 struct RayInput {
@@ -48,6 +48,7 @@ struct TrianglesGeomData {
 /* variables for double precision triangle mesh geometry */
 struct DPTriangleGeomData {
   double3 *vertex; // vertex buffer
+  float3 *aabbs; // AABB buffer 
   uint3 *index;  // index buffer
   double3 *normals; // normals buffer
   double4 *dprays; // double precision rays

--- a/include/xdg/gprt/sharedCode.h
+++ b/include/xdg/gprt/sharedCode.h
@@ -10,6 +10,14 @@ struct RayInput {
   uint32_t exclude_count;           // Number of excluded primitives
 };
 
+struct dblRayInput 
+{
+  double3 origin;
+  double3 direction;
+  int32_t* exclude_primitives; // Optional for excluding primitives
+  uint32_t exclude_count;           // Number of excluded primitives
+};
+
 struct RayOutput 
 {
   float distance;
@@ -17,7 +25,14 @@ struct RayOutput
   float3 normal;
 };
 
-/* variables for the triangle mesh geometry */
+struct dblRayOutput 
+{
+  double distance;
+  uint surf_id;
+  double3 normal;
+};
+
+/* variables for the single precision triangle mesh geometry */
 struct TrianglesGeomData {
   float3 *vertex; // vertex buffer
   uint3 *index;   // index buffer
@@ -26,15 +41,17 @@ struct TrianglesGeomData {
   int forward_vol; 
   int reverse_vol;
 };
-// /* variables for the triangle mesh geometry */
-// struct DPTriangleGeomData {
-//   double3 *vertex; // vertex buffer
-//   uint3 *index;  // index buffer
-//   double4 *dprays; // double precision rays
-//   uint id;       // surface id
-//   uint2 vols;    // parent volumes
-//   uint fbSize; // framebuffer size
-// };
+
+/* variables for double precision triangle mesh geometry */
+struct DPTriangleGeomData {
+  double3 *vertex; // vertex buffer
+  uint3 *index;  // index buffer
+  double3 *normals; // normals buffer
+  double4 *dprays; // double precision rays
+  uint id;       // surface id
+  int forward_vol;
+  int reverse_vol;
+};
 
 struct RayGenData {
   uint* frameBuffer;                     // Optional for debugging or visuals
@@ -50,6 +67,12 @@ struct RayFireData {
   RayOutput out;
 };
 
+struct dblRayFireData {
+  uint* frameBuffer;                     // Optional for debugging or visuals
+  SurfaceAccelerationStructure world;    // The top-level accel structure
+  dblRayInput ray;
+  dblRayOutput out;
+};
 
 /* variables for the miss program */
 struct MissProgData {
@@ -73,5 +96,10 @@ struct PushConstants {
 
 struct RayFirePushConstants {
   float dist_limit;
+  int orientation;
+};
+
+struct dblRayFirePushConstants {
+  double dist_limit;
   int orientation;
 };

--- a/src/gprt/dbl_deviceCode.slang
+++ b/src/gprt/dbl_deviceCode.slang
@@ -152,6 +152,8 @@ populate_aabbs(uint3 DispatchThreadID: SV_DispatchThreadID, uniform DPTriangleGe
     double3 dpaabbmax = max(max(A, B), C);
     float3 fpaabbmin = float3(dpaabbmin - float3(FLT_EPSILON, FLT_EPSILON, FLT_EPSILON));
     float3 fpaabbmax = float3(dpaabbmax + float3(FLT_EPSILON, FLT_EPSILON, FLT_EPSILON));
+    // printf("AABB %i: min(%f, %f, %f), max(%f, %f, %f)\n", primID, fpaabbmin.x, fpaabbmin.y, fpaabbmin.z,
+    //        fpaabbmax.x, fpaabbmax.y, fpaabbmax.z);
     record.aabbs[2 * primID] = fpaabbmin;
     record.aabbs[2 * primID + 1] = fpaabbmax;
 }
@@ -162,20 +164,21 @@ populate_aabbs(uint3 DispatchThreadID: SV_DispatchThreadID, uniform DPTriangleGe
 void DPTrianglePluckerIntersection(uniform DPTriangleGeomData record)
 {
 
-    printf("DPTrianglePluckerIntersection called!\n");
     uint rayID = DispatchRaysIndex().x;
     uint nRays = DispatchRaysDimensions().x;
 
-    if (rayID >= nRays) return; // Just in case we are out of bounds
-
-    // if ((pixelID.x == dims.x / 2) && (pixelID.y == dims.y / 2)) debug = true; // Debugging ray at center of screen
-    // if ((rayID == nRays / 2)) debug = true; // Debugging ray at the center of array
+    if (rayID >= nRays) {
+        printf("Early return at line %d: rayID (%u) >= nRays (%u)\n", __LINE__, rayID, nRays);
+        return;
+    }
 
     uint flags = RayFlags();
 
-    // Just skip if we for some reason cull both...
     if (((flags & RAY_FLAG_CULL_BACK_FACING_TRIANGLES) != 0) &&
-        ((flags & RAY_FLAG_CULL_FRONT_FACING_TRIANGLES) != 0)) return;
+        ((flags & RAY_FLAG_CULL_FRONT_FACING_TRIANGLES) != 0)) {
+        printf("Early return at line %d: Both cull flags set\n", __LINE__);
+        return;
+    }
 
     // Set the ray orientation based on the flags
     bool useOrientation = false;
@@ -211,6 +214,7 @@ void DPTrianglePluckerIntersection(uniform DPTriangleGeomData record)
 
     // If orientation is set, confirm that sign of plucker_coordinate indicate correct orientation of intersection
     if (useOrientation && orientation * plucker_coord0 > 0) {
+        printf("Early return at line %d: orientation * plucker_coord0 > 0\n", __LINE__);
         return;
     }
 
@@ -218,25 +222,33 @@ void DPTrianglePluckerIntersection(uniform DPTriangleGeomData record)
     double plucker_coord1 = plucker_edge_test(v1, v2, raya, rayb);
 
     // If orientation is set, confirm that sign of plucker_coordinate indicate correct orientation of intersection
-    if (useOrientation && orientation * plucker_coord1 > 0) return;
-    // If the orientation is not specified, all plucker_coords must be the same sign or zero.
-    else if ((0.0 < plucker_coord0 && 0.0 > plucker_coord1) || (0.0 > plucker_coord0 && 0.0 < plucker_coord1)) return;
+    if (useOrientation && orientation * plucker_coord1 > 0) {
+        printf("Early return at line %d: orientation * plucker_coord1 > 0\n", __LINE__);
+        return;
+    }
+    else if ((0.0 < plucker_coord0 && 0.0 > plucker_coord1) || (0.0 > plucker_coord0 && 0.0 < plucker_coord1)) {
+        printf("Early return at line %d: plucker_coord0 and plucker_coord1 have opposite signs\n", __LINE__);
+        return;
+    }
 
     // Determine the value of the third Plucker coordinate from edge 2
     double plucker_coord2 = plucker_edge_test(v2, v0, raya, rayb);
 
     // If orientation is set, confirm that sign of plucker_coordinate indicate correct orientation of intersection
-    if (useOrientation && orientation * plucker_coord2 > 0) return;
-    // If the orientation is not specified, all plucker_coords must be the same sign or zero.
+    if (useOrientation && orientation * plucker_coord2 > 0) {
+        printf("Early return at line %d: orientation * plucker_coord2 > 0\n", __LINE__);
+        return;
+    }
     else if ((0.0 < plucker_coord1 && 0.0 > plucker_coord2) || (0.0 > plucker_coord1 && 0.0 < plucker_coord2) ||
-             (0.0 < plucker_coord0 && 0.0 > plucker_coord2) || (0.0 > plucker_coord0 && 0.0 < plucker_coord2))
-    {
-        return; // EXIT_EARLY;
+             (0.0 < plucker_coord0 && 0.0 > plucker_coord2) || (0.0 > plucker_coord0 && 0.0 < plucker_coord2)) {
+        printf("Early return at line %d: plucker_coords have opposite signs\n", __LINE__);
+        return;
     }
 
     // check for coplanar case to avoid dividing by zero
     if (0.0 == plucker_coord0 && 0.0 == plucker_coord1 && 0.0 == plucker_coord2) {
-        return; // EXIT_EARLY;
+        printf("Early return at line %d: coplanar case, all plucker_coords are zero\n", __LINE__);
+        return;
     }
 
     // Get the distance to the intersection point

--- a/src/gprt/dbl_deviceCode.slang
+++ b/src/gprt/dbl_deviceCode.slang
@@ -70,7 +70,7 @@ void ray_fire_miss(inout RayFirePayload payload) {
 // This ray generation program will kick off the ray tracing process,
 // generating rays and tracing them into the world.
 [shader("raygeneration")]
-void ray_fire(uniform RayGenData record, uniform TrianglesGeomData mesh) {
+void ray_fire(uniform dblRayGenData record, uniform DPTriangleGeomData mesh) {
     RayFirePayload payload;
     uint rayID = DispatchRaysIndex().x;
     
@@ -81,28 +81,26 @@ void ray_fire(uniform RayGenData record, uniform TrianglesGeomData mesh) {
 
     // Trace the ray into the scene
     RayDesc rayDesc;
-    rayDesc.Origin = record.ray.origin;
-    rayDesc.Direction = normalize(record.ray.direction);
+    rayDesc.Origin = float3(record.ray[rayID].origin);
+    rayDesc.Direction = normalize(float3(record.ray[rayID].direction));
     rayDesc.TMin = 1e-4f; // non-zero to avoid self-intersection
-    rayDesc.TMax = rayFirePC.dist_limit; // distance limit from push constants
-    
+    rayDesc.TMax = rayFirePC.dist_limit; // distance limit from push constants    
 
     // Pass the ray's origin and direction to the payload
     payload.distance = -1.0f;
     payload.surf_id = ~0u;   
     payload.tlas = record.world;
 
-
-    uint rayFlagCull = (rayFirePC.orientation == 1) 
-                   ? RAY_FLAG_CULL_FRONT_FACING_TRIANGLES 
-                   : RAY_FLAG_CULL_BACK_FACING_TRIANGLES;
+    // uint rayFlagCull = (rayFirePC.orientation == 1) 
+    //                ? RAY_FLAG_CULL_FRONT_FACING_TRIANGLES 
+    //                : RAY_FLAG_CULL_BACK_FACING_TRIANGLES;
     
 
     // printf("Distance Limit: %f\n", rayFirePC.dist_limit);
     // printf("Orientation: %u\n", rayFirePC.orientation);
     // printf("TMax before TraceRay: %f\n PC.dist_limit: %f\n", rayDesc.TMax, rayFirePC.dist_limit);
     // printf("Exclude_primitive size: %i \n", record.ray.exclude_count);
-    TraceRay(record.world, rayFlagCull, 0xff, 0, 1, 0, rayDesc, payload);
+    TraceRay(record.world, RAY_FLAG_CULL_FRONT_FACING_TRIANGLES, 0xff, 0, 1, 0, rayDesc, payload);
 
     // Store the distance to the hit point and the surface ID in buffers for CPU
     record.out.distance = payload.distance;
@@ -161,11 +159,12 @@ populate_aabbs(uint3 DispatchThreadID: SV_DispatchThreadID, uniform DPTriangleGe
 // ------------------------------------------------ CUSTOM INTERSECTION SHADERS ------------------------------------------------
 /* 1D ray generation intersection with a double precision triangle using the Plucker intersection algorithm*/
 [shader("intersection")]
-void DPTrianglePluckerIntersection(uniform DPTriangleGeomData record)
+void DPTrianglePluckerIntersection(uniform DPTriangleGeomData record, uniform dblRayGenData rayGenData)
 {
 
     uint rayID = DispatchRaysIndex().x;
     uint nRays = DispatchRaysDimensions().x;
+    printf("DPTrianglePluckerIntersection called with rayID: %u, nRays: %u\n", rayID, nRays);
 
     if (rayID >= nRays) {
         printf("Early return at line %d: rayID (%u) >= nRays (%u)\n", __LINE__, rayID, nRays);
@@ -199,12 +198,25 @@ void DPTrianglePluckerIntersection(uniform DPTriangleGeomData record)
     double3 v2 = record.vertex[indices.z];
 
     // Recover our double precision rays from the stored buffer
-    double4 raydata1 = record.dprays[rayID * 2 + 0];
-    double4 raydata2 = record.dprays[rayID * 2 + 1];
-    double3 origin = double3(raydata1.x, raydata1.y, raydata1.z);
-    double3 direction = double3(raydata2.x, raydata2.y, raydata2.z);
-    double tMin = raydata1.w;
-    double tMax = raydata2.w;
+    // double4 raydata1 = record.dprays[rayID * 2 + 0];
+    // double4 raydata2 = record.dprays[rayID * 2 + 1];
+    // double3 origin = double3(raydata1.x, raydata1.y, raydata1.z);
+    // double3 direction = double3(raydata2.x, raydata2.y, raydata2.z);
+    // double tMin = raydata1.w;
+    // double tMax = raydata2.w;
+
+    double3 origin = record.ray[rayID].origin;
+    double3 direction = record.ray[rayID].direction;
+    printf("origin: (%f, %f, %f), direction: (%f, %f, %f)\n",
+           origin.x, origin.y, origin.z, direction.x, direction.y, direction.z);    
+
+    // double3 origin = {0.0, 0.0, 0.0}; // Placeholder for origin
+    // double3 direction = {0.0, 0.0, 0.0}; // Placeholder for direction
+    // tMin = rayGenData.ray.tMin;
+    // tMax = rayGenData.ray.tMax;
+
+    // printf("origin: (%f, %f, %f), direction: (%f, %f, %f)\n",
+    //        origin.x, origin.y, origin.z, direction.x, direction.y, direction.z);
 
     const double3 raya = direction;
     const double3 rayb = dp_cross(v1 - v0, v2 - v0);

--- a/src/gprt/dbl_deviceCode.slang
+++ b/src/gprt/dbl_deviceCode.slang
@@ -11,51 +11,40 @@ struct Payload {
 };
 
 struct RayFirePayload {
-    float distance;    // Distance to intersection
+    double distance;    // Distance to intersection
     int surf_id;     // ID of the surface hit
-    int vol_id;       // ID of the volume the ray is in 
+    int2 vol_ids;       // ID of the volume the ray is in
     SurfaceAccelerationStructure tlas;
     int next_vol;      // ID of the next volume
-    float3 normal;
+    double3 normal;
 };
 
+struct DPAttribute
+{
+  float2 bc;
+};
+
+
 [shader("closesthit")]
-void ray_fire_hit(uniform TrianglesGeomData record, inout RayFirePayload payload, in float2 bc) {
+void ray_fire_hit(uniform DPTriangleGeomData record, inout RayFirePayload payload, in float2 bc) {
     // Distance from the ray origin to the hit point
     uint hit_kind = HitKind();
+    uint rayID = DispatchRaysIndex().x;
 
-    // if (hit_kind == HIT_KIND_TRIANGLE_FRONT_FACE) {
-    //   payload.vol_ids.x = record.vols[0]; // moving out of this volume
-    //   payload.vol_ids.y = record.vols[1]; // moving into this volume
-    //   payload.next_vol = record.bf_vol; // moving into the backface volume
+
+    // if (hit_kind == HIT_KIND_TRIANGLE_FRONT_FACE){
+    //     payload.vol_ids.x = record.vols[0];
+    //     payload.vol_ids.y = record.vols[1];
+    //     payload.next_vol = record.reverse_vol;
     // }
     // else {
-    //   payload.vol_ids.x = record.vols[1]; // moving out of this volume
-    //   payload.vol_ids.y = record.vols[0]; // moving into this volume
-    //   payload.next_vol = record.ff_vol; // moving into the frontface volume
-    //   uint2 pixelID = DispatchRaysIndex().xy;
-    //   uint2 centerID = DispatchRaysDimensions().xy / 2;
-    //   if (all(pixelID == centerID)) {
-    //     // printf("Index of next volume BLAS %i", payload.next_vol);
-    //     // printf("Going from volume %i into volume %i, ", payload.vol_ids.x, payload.vol_ids.y);
-    //     printf("\nSurface ID: %i \n"
-    //     "Geom Data Vols: {%i, %i}\n"
-    //     "Index of next volume BLAS %i\n", record.id, record.vols[1], record.vols[0], record.ff_vol);
-    //   }
+    //     payload.vol_ids.x = record.vols[1];
+    //     payload.vol_ids.y = record.vols[0];
+    //     payload.next_vol = record.forward_vol;
     // }
- 
-
-    payload.distance = RayTCurrent();
-    payload.surf_id = record.id;
-    payload.normal = record.normals[PrimitiveIndex()];
-
-    // Print the ray's origin and direction
-    // printf("Closest Hit called!");
-    // printf("Normal returned: (%f, %f, %f)", payload.normal.x, payload.normal.y, payload.normal.z);
-    // printf("Closest Hit called! Distance: %f, surf_id: %u\n", payload.distance, record.id);
-    // printf("Ray Origin: (%f, %f, %f)\n", payload.origin.x, payload.origin.y, payload.origin.z);
-    // printf("Ray Direction: (%f, %f, %f)\n", payload.direction.x, payload.direction.y, payload.direction.z);
-    // printf("Barycentrics: (%f, %f)\n", bc.x, bc.y);
+    // payload.distance = record.out[rayID].distance;
+    // payload.surf_id = record.out[rayID].surf_id;
+    // payload.normal = record.normals[PrimitiveIndex()];
 }
 
 [shader("miss")]
@@ -73,7 +62,7 @@ void ray_fire_miss(inout RayFirePayload payload) {
 void ray_fire(uniform dblRayGenData record, uniform DPTriangleGeomData mesh) {
     RayFirePayload payload;
     uint rayID = DispatchRaysIndex().x;
-    
+
     // printf("Ray Generation Shader called with :");
     // printf("Ray Origin: (%f, %f, %f)\n", record.ray.origin.x, record.ray.origin.y, record.ray.origin.z);
     // printf("Ray Direction: (%f, %f, %f)\n", record.ray.direction.x, record.ray.direction.y, record.ray.direction.z);
@@ -84,17 +73,17 @@ void ray_fire(uniform dblRayGenData record, uniform DPTriangleGeomData mesh) {
     rayDesc.Origin = float3(record.ray[rayID].origin);
     rayDesc.Direction = normalize(float3(record.ray[rayID].direction));
     rayDesc.TMin = 1e-4f; // non-zero to avoid self-intersection
-    rayDesc.TMax = rayFirePC.dist_limit; // distance limit from push constants    
+    rayDesc.TMax = rayFirePC.dist_limit; // distance limit from push constants
 
     // Pass the ray's origin and direction to the payload
     payload.distance = -1.0f;
-    payload.surf_id = ~0u;   
+    payload.surf_id = ~0u;
     payload.tlas = record.world;
 
-    // uint rayFlagCull = (rayFirePC.orientation == 1) 
-    //                ? RAY_FLAG_CULL_FRONT_FACING_TRIANGLES 
+    // uint rayFlagCull = (rayFirePC.orientation == 1)
+    //                ? RAY_FLAG_CULL_FRONT_FACING_TRIANGLES
     //                : RAY_FLAG_CULL_BACK_FACING_TRIANGLES;
-    
+
 
     // printf("Distance Limit: %f\n", rayFirePC.dist_limit);
     // printf("Orientation: %u\n", rayFirePC.orientation);
@@ -103,8 +92,8 @@ void ray_fire(uniform dblRayGenData record, uniform DPTriangleGeomData mesh) {
     TraceRay(record.world, RAY_FLAG_CULL_FRONT_FACING_TRIANGLES, 0xff, 0, 1, 0, rayDesc, payload);
 
     // Store the distance to the hit point and the surface ID in buffers for CPU
-    record.out.distance = payload.distance;
-    record.out.surf_id = payload.surf_id;
+    record.out[rayID].distance = payload.distance;
+    record.out[rayID].surf_id = payload.surf_id;
 }
 
 [shader("raygeneration")]
@@ -123,16 +112,15 @@ void point_in_volume(uniform RayGenData record, uniform TrianglesGeomData mesh) 
     rayDesc.Direction = normalize(record.ray.direction);
     rayDesc.TMin = 1e-4f; // non-zero to avoid self-intersection
     rayDesc.TMax = 1e30f;
-    
+
     // Pass the ray's origin and direction to the payload
-    payload.surf_id = ~0u;   
-    payload.tlas = record.world;    
+    payload.surf_id = ~0u;
+    payload.tlas = record.world;
 
     TraceRay(record.world, RAY_FLAG_NONE, 0xff, 0, 2, 0, rayDesc, payload);
 
     // Store the distance to the hit point and the surface ID in buffers for CPU
     record.out.surf_id = payload.surf_id;
-    record.out.normal = payload.normal;
 }
 
 // ------------------------------------------------- Compute Shaders -------------------------------------------------
@@ -157,123 +145,33 @@ populate_aabbs(uint3 DispatchThreadID: SV_DispatchThreadID, uniform DPTriangleGe
 }
 
 // ------------------------------------------------ CUSTOM INTERSECTION SHADERS ------------------------------------------------
+
+
 /* 1D ray generation intersection with a double precision triangle using the Plucker intersection algorithm*/
+struct TestAttr {
+    float2 bc;
+    float t;
+    double a;
+};
+
 [shader("intersection")]
-void DPTrianglePluckerIntersection(uniform DPTriangleGeomData record, uniform dblRayGenData rayGenData)
+void DPTrianglePluckerIntersection()
 {
+    float t = 1.0f;
+    double a = 2.021392392932939239239239;
+    double b = 1.021392392932939239239239;
+    double c = a*b;
+    TestAttr attr;
+    attr.a = c;
+    attr.bc = float2(0.3f, 0.3f);
+    attr.t = t;
 
-    uint rayID = DispatchRaysIndex().x;
-    uint nRays = DispatchRaysDimensions().x;
-    printf("DPTrianglePluckerIntersection called with rayID: %u, nRays: %u\n", rayID, nRays);
-
-    if (rayID >= nRays) {
-        printf("Early return at line %d: rayID (%u) >= nRays (%u)\n", __LINE__, rayID, nRays);
-        return;
+    if (ReportHit(t, HIT_KIND_TRIANGLE_FRONT_FACE, attr)) {
+        // Optional: log something
     }
-
-    uint flags = RayFlags();
-
-    if (((flags & RAY_FLAG_CULL_BACK_FACING_TRIANGLES) != 0) &&
-        ((flags & RAY_FLAG_CULL_FRONT_FACING_TRIANGLES) != 0)) {
-        printf("Early return at line %d: Both cull flags set\n", __LINE__);
-        return;
-    }
-
-    // Set the ray orientation based on the flags
-    bool useOrientation = false;
-    int orientation = 0;
-    if ((flags & RAY_FLAG_CULL_BACK_FACING_TRIANGLES) != 0) {
-        orientation = -1;
-        useOrientation = true;
-    }
-    else if ((flags & RAY_FLAG_CULL_FRONT_FACING_TRIANGLES) != 0) {
-        orientation = 1;
-        useOrientation = true;
-    }
-
-    int primID = PrimitiveIndex();
-    int3 indices = record.index[primID];
-    double3 v0 = record.vertex[indices.x];
-    double3 v1 = record.vertex[indices.y];
-    double3 v2 = record.vertex[indices.z];
-
-    // Recover our double precision rays from the stored buffer
-    // double4 raydata1 = record.dprays[rayID * 2 + 0];
-    // double4 raydata2 = record.dprays[rayID * 2 + 1];
-    // double3 origin = double3(raydata1.x, raydata1.y, raydata1.z);
-    // double3 direction = double3(raydata2.x, raydata2.y, raydata2.z);
-    // double tMin = raydata1.w;
-    // double tMax = raydata2.w;
-
-    double3 origin = record.ray[rayID].origin;
-    double3 direction = record.ray[rayID].direction;
-    printf("origin: (%f, %f, %f), direction: (%f, %f, %f)\n",
-           origin.x, origin.y, origin.z, direction.x, direction.y, direction.z);    
-
-    // double3 origin = {0.0, 0.0, 0.0}; // Placeholder for origin
-    // double3 direction = {0.0, 0.0, 0.0}; // Placeholder for direction
-    // tMin = rayGenData.ray.tMin;
-    // tMax = rayGenData.ray.tMax;
-
-    // printf("origin: (%f, %f, %f), direction: (%f, %f, %f)\n",
-    //        origin.x, origin.y, origin.z, direction.x, direction.y, direction.z);
-
-    const double3 raya = direction;
-    const double3 rayb = dp_cross(v1 - v0, v2 - v0);
-
-    // Determine the value of first Plucker coordinate from edge 0
-    double plucker_coord0 = plucker_edge_test(v0, v1, raya, rayb);
-
-    // If orientation is set, confirm that sign of plucker_coordinate indicate correct orientation of intersection
-    if (useOrientation && orientation * plucker_coord0 > 0) {
-        printf("Early return at line %d: orientation * plucker_coord0 > 0\n", __LINE__);
-        return;
-    }
-
-    // Determine the value of the second Plucker coordinate from edge 1
-    double plucker_coord1 = plucker_edge_test(v1, v2, raya, rayb);
-
-    // If orientation is set, confirm that sign of plucker_coordinate indicate correct orientation of intersection
-    if (useOrientation && orientation * plucker_coord1 > 0) {
-        printf("Early return at line %d: orientation * plucker_coord1 > 0\n", __LINE__);
-        return;
-    }
-    else if ((0.0 < plucker_coord0 && 0.0 > plucker_coord1) || (0.0 > plucker_coord0 && 0.0 < plucker_coord1)) {
-        printf("Early return at line %d: plucker_coord0 and plucker_coord1 have opposite signs\n", __LINE__);
-        return;
-    }
-
-    // Determine the value of the third Plucker coordinate from edge 2
-    double plucker_coord2 = plucker_edge_test(v2, v0, raya, rayb);
-
-    // If orientation is set, confirm that sign of plucker_coordinate indicate correct orientation of intersection
-    if (useOrientation && orientation * plucker_coord2 > 0) {
-        printf("Early return at line %d: orientation * plucker_coord2 > 0\n", __LINE__);
-        return;
-    }
-    else if ((0.0 < plucker_coord1 && 0.0 > plucker_coord2) || (0.0 > plucker_coord1 && 0.0 < plucker_coord2) ||
-             (0.0 < plucker_coord0 && 0.0 > plucker_coord2) || (0.0 > plucker_coord0 && 0.0 < plucker_coord2)) {
-        printf("Early return at line %d: plucker_coords have opposite signs\n", __LINE__);
-        return;
-    }
-
-    // check for coplanar case to avoid dividing by zero
-    if (0.0 == plucker_coord0 && 0.0 == plucker_coord1 && 0.0 == plucker_coord2) {
-        printf("Early return at line %d: coplanar case, all plucker_coords are zero\n", __LINE__);
-        return;
-    }
-
-    // Get the distance to the intersection point
-    const double inverse_sum = 1.0 / (plucker_coord0 + plucker_coord1 + plucker_coord2);
-    const double3 intersection = double3(plucker_coord0 * inverse_sum * v2 +
-                                         plucker_coord1 * inverse_sum * v0 +
-                                         plucker_coord2 * inverse_sum * v1);
-
-    // To minimise numerical error, get index of largest magnitude direction component
-    int idx = 0;
-    printf("We are here in the double precision intersection shader!\n");
-
 }
+
+// ------------------------------------------------- Helper functions -------------------------------------------------
 
 // Double precision cross product
 double3 dp_cross(in double3 a, in double3 b) { return double3(a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x); }
@@ -316,4 +214,16 @@ inline bool first(in double3 a, in double3 b)
     if (a.y == b.y && a.z < b.z) return true;
 
     return false;
+}
+
+double3 dcross (in double3 a, in double3 b) { return double3(a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x); }
+
+float next_after(float a) {
+  uint a_ = asuint(a);
+  if (a < 0) {
+    a_--;
+  } else {
+    a_++;
+  }
+  return asfloat(a_);
 }

--- a/src/gprt/dbl_deviceCode.slang
+++ b/src/gprt/dbl_deviceCode.slang
@@ -64,6 +64,7 @@ void ray_fire_miss(inout RayFirePayload payload) {
     payload.distance = -1.0f;
     payload.surf_id = ~0u;
     payload.normal = {0.0, 0.0, 0.0};
+    printf("Miss shader called!\n");
 }
 
 // This ray generation program will kick off the ray tracing process,
@@ -141,7 +142,7 @@ void point_in_volume(uniform RayGenData record, uniform TrianglesGeomData mesh) 
 [shader("compute")]
 [numthreads(1, 1, 1)]
 void
-ComputeBounds(uint3 DispatchThreadID: SV_DispatchThreadID, uniform DPTriangleGeomData record) {
+populate_aabbs(uint3 DispatchThreadID: SV_DispatchThreadID, uniform DPTriangleGeomData record) {
     int primID = DispatchThreadID.x;
     int3 indices = record.index[primID];
     double3 A = record.vertex[indices.x];
@@ -292,25 +293,3 @@ inline bool first(in double3 a, in double3 b)
 
     return false;
 }
-
-[shader("closesthit")]
-void render_hits(uniform TrianglesGeomData record, inout Payload payload, in float2 bc) {
-    // Threshold to determine edge thickness
-    const float edgeThreshold = 0.02;
-
-    // Check if the ray is near an edge using barycentric coordinates
-    if (bc.x < edgeThreshold || bc.y < edgeThreshold || (1.0 - (bc.x + bc.y)) < edgeThreshold) {
-        // Near an edge: set color to black
-        payload.color = float3(0.0, 0.0, 0.0);
-    } else { // Generate a unique color for each parent volume
-        // uint vol = record.vols.x; // Get first parent volume ID
-        // float r = float((vol * 37) % 256) / 255.0;  
-        // float g = float((vol * 73) % 256) / 255.0;  
-        // float b = float((vol * 151) % 256) / 255.0; 
-        // payload.color = float3(r, g, b);
-        payload.color = float3(0.0, 1.0, 0.0);
-    }
-
-    // printf("Closest Hit called! Parent Vols: (%u, %u), surf_id: %u\n", record.forward_vol, record.reverse_vol, record.id);
-}
-

--- a/src/gprt/dbl_deviceCode.slang
+++ b/src/gprt/dbl_deviceCode.slang
@@ -20,7 +20,7 @@ struct RayFirePayload {
 };
 
 [shader("closesthit")]
-void dbl_ray_fire_hit(uniform TrianglesGeomData record, inout RayFirePayload payload, in float2 bc) {
+void ray_fire_hit(uniform TrianglesGeomData record, inout RayFirePayload payload, in float2 bc) {
     // Distance from the ray origin to the hit point
     uint hit_kind = HitKind();
 
@@ -59,21 +59,20 @@ void dbl_ray_fire_hit(uniform TrianglesGeomData record, inout RayFirePayload pay
 }
 
 [shader("miss")]
-void dbl_ray_fire_miss(inout RayFirePayload payload) {
+void ray_fire_miss(inout RayFirePayload payload) {
     // Set the miss payload to default values
     payload.distance = -1.0f;
     payload.surf_id = ~0u;
     payload.normal = {0.0, 0.0, 0.0};
-    // printf("Miss shader called!\n");
 }
 
 // This ray generation program will kick off the ray tracing process,
 // generating rays and tracing them into the world.
 [shader("raygeneration")]
-void dbl_ray_fire(uniform RayGenData record, uniform TrianglesGeomData mesh) {
+void ray_fire(uniform RayGenData record, uniform TrianglesGeomData mesh) {
     RayFirePayload payload;
     uint rayID = DispatchRaysIndex().x;
-
+    
     // printf("Ray Generation Shader called with :");
     // printf("Ray Origin: (%f, %f, %f)\n", record.ray.origin.x, record.ray.origin.y, record.ray.origin.z);
     // printf("Ray Direction: (%f, %f, %f)\n", record.ray.direction.x, record.ray.direction.y, record.ray.direction.z);
@@ -110,7 +109,7 @@ void dbl_ray_fire(uniform RayGenData record, uniform TrianglesGeomData mesh) {
 }
 
 [shader("raygeneration")]
-void dbl_point_in_volume(uniform RayGenData record, uniform TrianglesGeomData mesh) {
+void point_in_volume(uniform RayGenData record, uniform TrianglesGeomData mesh) {
     RayFirePayload payload;
     uint rayID = DispatchRaysIndex().x;
 
@@ -137,11 +136,32 @@ void dbl_point_in_volume(uniform RayGenData record, uniform TrianglesGeomData me
     record.out.normal = payload.normal;
 }
 
+// ------------------------------------------------- Compute Shaders -------------------------------------------------
+/* A shader to compute and store AABB min/maxes in single precision using double precision coords*/
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void
+ComputeBounds(uint3 DispatchThreadID: SV_DispatchThreadID, uniform DPTriangleGeomData record) {
+    int primID = DispatchThreadID.x;
+    int3 indices = record.index[primID];
+    double3 A = record.vertex[indices.x];
+    double3 B = record.vertex[indices.y];
+    double3 C = record.vertex[indices.z];
+    double3 dpaabbmin = min(min(A, B), C);
+    double3 dpaabbmax = max(max(A, B), C);
+    float3 fpaabbmin = float3(dpaabbmin - float3(FLT_EPSILON, FLT_EPSILON, FLT_EPSILON));
+    float3 fpaabbmax = float3(dpaabbmax + float3(FLT_EPSILON, FLT_EPSILON, FLT_EPSILON));
+    record.aabbs[2 * primID] = fpaabbmin;
+    record.aabbs[2 * primID + 1] = fpaabbmax;
+}
+
 // ------------------------------------------------ CUSTOM INTERSECTION SHADERS ------------------------------------------------
 /* 1D ray generation intersection with a double precision triangle using the Plucker intersection algorithm*/
 [shader("intersection")]
 void DPTrianglePluckerIntersection(uniform DPTriangleGeomData record)
 {
+
+    printf("DPTrianglePluckerIntersection called!\n");
     uint rayID = DispatchRaysIndex().x;
     uint nRays = DispatchRaysDimensions().x;
 
@@ -226,7 +246,7 @@ void DPTrianglePluckerIntersection(uniform DPTriangleGeomData record)
 
     // To minimise numerical error, get index of largest magnitude direction component
     int idx = 0;
-    
+    printf("We are here in the double precision intersection shader!\n");
 
 }
 
@@ -272,3 +292,25 @@ inline bool first(in double3 a, in double3 b)
 
     return false;
 }
+
+[shader("closesthit")]
+void render_hits(uniform TrianglesGeomData record, inout Payload payload, in float2 bc) {
+    // Threshold to determine edge thickness
+    const float edgeThreshold = 0.02;
+
+    // Check if the ray is near an edge using barycentric coordinates
+    if (bc.x < edgeThreshold || bc.y < edgeThreshold || (1.0 - (bc.x + bc.y)) < edgeThreshold) {
+        // Near an edge: set color to black
+        payload.color = float3(0.0, 0.0, 0.0);
+    } else { // Generate a unique color for each parent volume
+        // uint vol = record.vols.x; // Get first parent volume ID
+        // float r = float((vol * 37) % 256) / 255.0;  
+        // float g = float((vol * 73) % 256) / 255.0;  
+        // float b = float((vol * 151) % 256) / 255.0; 
+        // payload.color = float3(r, g, b);
+        payload.color = float3(0.0, 1.0, 0.0);
+    }
+
+    // printf("Closest Hit called! Parent Vols: (%u, %u), surf_id: %u\n", record.forward_vol, record.reverse_vol, record.id);
+}
+

--- a/src/gprt/dbl_deviceCode.slang
+++ b/src/gprt/dbl_deviceCode.slang
@@ -3,81 +3,138 @@
 [[vk::push_constant]]
 PushConstants pc;
 
+[[vk::push_constant]]
+RayFirePushConstants rayFirePC;
+
 struct Payload {
     float3 color;
 };
 
-// This closest hit shader runs when a ray hits a triangle.
-// It processes per-geometry data and communicates with the ray generation shader.
-// - The first parameter is the shader record type, representing SBT parameters for this shader.
-// - The second is the ray payload type, used for passing data between shaders.
-// - The third is the intersection attributes. For triangles, these are two "barycentrics", used
-//   for interpolating per-vertex values.
-[shader("closesthit")]
-void TriangleMesh(uniform TrianglesGeomData record, inout Payload payload, in float2 bc) {
-    // Threshold to determine edge thickness
-    const float edgeThreshold = 0.02;
+struct RayFirePayload {
+    float distance;    // Distance to intersection
+    int surf_id;     // ID of the surface hit
+    int vol_id;       // ID of the volume the ray is in 
+    SurfaceAccelerationStructure tlas;
+    int next_vol;      // ID of the next volume
+    float3 normal;
+};
 
-    // Check if the ray is near an edge using barycentric coordinates
-    if (bc.x < edgeThreshold || bc.y < edgeThreshold || (1.0 - (bc.x + bc.y)) < edgeThreshold) {
-        // Near an edge: set color to black
-        payload.color = float3(0.0, 0.0, 0.0);
-    } else { // Generate a unique color for each parent volume
-        uint vol = record.vols.x; // Get first parent volume ID
-        float r = float((vol * 37) % 256) / 255.0;  
-        float g = float((vol * 73) % 256) / 255.0;  
-        float b = float((vol * 151) % 256) / 255.0; 
-        payload.color = float3(r, g, b);
-    }
+[shader("closesthit")]
+void dbl_ray_fire_hit(uniform TrianglesGeomData record, inout RayFirePayload payload, in float2 bc) {
+    // Distance from the ray origin to the hit point
+    uint hit_kind = HitKind();
+
+    // if (hit_kind == HIT_KIND_TRIANGLE_FRONT_FACE) {
+    //   payload.vol_ids.x = record.vols[0]; // moving out of this volume
+    //   payload.vol_ids.y = record.vols[1]; // moving into this volume
+    //   payload.next_vol = record.bf_vol; // moving into the backface volume
+    // }
+    // else {
+    //   payload.vol_ids.x = record.vols[1]; // moving out of this volume
+    //   payload.vol_ids.y = record.vols[0]; // moving into this volume
+    //   payload.next_vol = record.ff_vol; // moving into the frontface volume
+    //   uint2 pixelID = DispatchRaysIndex().xy;
+    //   uint2 centerID = DispatchRaysDimensions().xy / 2;
+    //   if (all(pixelID == centerID)) {
+    //     // printf("Index of next volume BLAS %i", payload.next_vol);
+    //     // printf("Going from volume %i into volume %i, ", payload.vol_ids.x, payload.vol_ids.y);
+    //     printf("\nSurface ID: %i \n"
+    //     "Geom Data Vols: {%i, %i}\n"
+    //     "Index of next volume BLAS %i\n", record.id, record.vols[1], record.vols[0], record.ff_vol);
+    //   }
+    // }
+ 
+
+    payload.distance = RayTCurrent();
+    payload.surf_id = record.id;
+    payload.normal = record.normals[PrimitiveIndex()];
+
+    // Print the ray's origin and direction
+    // printf("Closest Hit called!");
+    // printf("Normal returned: (%f, %f, %f)", payload.normal.x, payload.normal.y, payload.normal.z);
+    // printf("Closest Hit called! Distance: %f, surf_id: %u\n", payload.distance, record.id);
+    // printf("Ray Origin: (%f, %f, %f)\n", payload.origin.x, payload.origin.y, payload.origin.z);
+    // printf("Ray Direction: (%f, %f, %f)\n", payload.direction.x, payload.direction.y, payload.direction.z);
+    // printf("Barycentrics: (%f, %f)\n", bc.x, bc.y);
+}
+
+[shader("miss")]
+void dbl_ray_fire_miss(inout RayFirePayload payload) {
+    // Set the miss payload to default values
+    payload.distance = -1.0f;
+    payload.surf_id = ~0u;
+    payload.normal = {0.0, 0.0, 0.0};
+    // printf("Miss shader called!\n");
 }
 
 // This ray generation program will kick off the ray tracing process,
 // generating rays and tracing them into the world.
 [shader("raygeneration")]
-void raygen(uniform RayGenData record) {
-    Payload payload;
-    uint2 pixelID = DispatchRaysIndex().xy;
-    uint2 iResolution = DispatchRaysDimensions().xy;
+void dbl_ray_fire(uniform RayGenData record, uniform TrianglesGeomData mesh) {
+    RayFirePayload payload;
+    uint rayID = DispatchRaysIndex().x;
 
-    // Use camera parameters from PushConstants
-    float3 ro = pc.camera.pos; // Camera position
-    float3 ww = normalize(pc.camera.dir_00); // Forward direction
-    float3 uu = normalize(pc.camera.dir_du); // Horizontal direction
-    float3 vv = normalize(pc.camera.dir_dv); // Vertical direction
+    // printf("Ray Generation Shader called with :");
+    // printf("Ray Origin: (%f, %f, %f)\n", record.ray.origin.x, record.ray.origin.y, record.ray.origin.z);
+    // printf("Ray Direction: (%f, %f, %f)\n", record.ray.direction.x, record.ray.direction.y, record.ray.direction.z);
+    // printf("Excluded Primitives.size(): %i \n", record.ray.exclude_count);
 
-    float3 tot = float3(0.0);
+    // Trace the ray into the scene
+    RayDesc rayDesc;
+    rayDesc.Origin = record.ray.origin;
+    rayDesc.Direction = normalize(record.ray.direction);
+    rayDesc.TMin = 1e-4f; // non-zero to avoid self-intersection
+    rayDesc.TMax = rayFirePC.dist_limit; // distance limit from push constants
+    
 
-    for (int m = 0; m < AA; m++)
-        for (int n = 0; n < AA; n++)
-        {
-            // Pixel coordinates
-            float2 o = float2(float(m), float(n)) / float(AA) - 0.5;
-            float2 p = (2.0 * (pixelID + o) - iResolution.xy) / iResolution.y;
+    // Pass the ray's origin and direction to the payload
+    payload.distance = -1.0f;
+    payload.surf_id = ~0u;   
+    payload.tlas = record.world;
 
-            // Create view ray
-            float3 rd = normalize(p.x * uu + p.y * vv + ww);
 
-            // Trace the ray into the scene
-            RayDesc rayDesc;
-            rayDesc.Origin = ro;
-            rayDesc.Direction = rd;
-            rayDesc.TMin = 0.0;
-            rayDesc.TMax = 10000.0;
-            TraceRay(record.world, RAY_FLAG_NONE, 0xff, 0, 1, 0, rayDesc, payload);
+    uint rayFlagCull = (rayFirePC.orientation == 1) 
+                   ? RAY_FLAG_CULL_FRONT_FACING_TRIANGLES 
+                   : RAY_FLAG_CULL_BACK_FACING_TRIANGLES;
+    
 
-            // Accumulate the color
-            tot += payload.color;
-        }
-    tot /= float(AA * AA);
+    // printf("Distance Limit: %f\n", rayFirePC.dist_limit);
+    // printf("Orientation: %u\n", rayFirePC.orientation);
+    // printf("TMax before TraceRay: %f\n PC.dist_limit: %f\n", rayDesc.TMax, rayFirePC.dist_limit);
+    // printf("Exclude_primitive size: %i \n", record.ray.exclude_count);
+    TraceRay(record.world, rayFlagCull, 0xff, 0, 1, 0, rayDesc, payload);
 
-    const int fbOfs = pixelID.x + iResolution.x * pixelID.y;
-    record.frameBuffer[fbOfs] = gprt::make_bgra(tot);
+    // Store the distance to the hit point and the surface ID in buffers for CPU
+    record.out.distance = payload.distance;
+    record.out.surf_id = payload.surf_id;
 }
 
-[shader("miss")]
-void miss(inout Payload payload) {
-    // Set the background color to light gray
-    payload.color = float3(0.8, 0.8, 0.8);
+[shader("raygeneration")]
+void dbl_point_in_volume(uniform RayGenData record, uniform TrianglesGeomData mesh) {
+    RayFirePayload payload;
+    uint rayID = DispatchRaysIndex().x;
+
+    // printf("Ray Generation Shader called with :");
+    // printf("Ray Origin: (%f, %f, %f)\n", record.ray.origin.x, record.ray.origin.y, record.ray.origin.z);
+    // printf("Ray Direction: (%f, %f, %f)\n", record.ray.direction.x, record.ray.direction.y, record.ray.direction.z);
+    // printf("Excluded Primitives.size(): %i \n", record.ray.exclude_count);
+
+    // Trace the ray into the scene
+    RayDesc rayDesc;
+    rayDesc.Origin = record.ray.origin;
+    rayDesc.Direction = normalize(record.ray.direction);
+    rayDesc.TMin = 1e-4f; // non-zero to avoid self-intersection
+    rayDesc.TMax = 1e30f;
+    
+    // Pass the ray's origin and direction to the payload
+    payload.surf_id = ~0u;   
+    payload.tlas = record.world;    
+
+    TraceRay(record.world, RAY_FLAG_NONE, 0xff, 0, 2, 0, rayDesc, payload);
+
+    // Store the distance to the hit point and the surface ID in buffers for CPU
+    record.out.surf_id = payload.surf_id;
+    record.out.normal = payload.normal;
 }
 
 // ------------------------------------------------ CUSTOM INTERSECTION SHADERS ------------------------------------------------

--- a/src/gprt/flt_deviceCode.slang
+++ b/src/gprt/flt_deviceCode.slang
@@ -52,13 +52,14 @@ void render_mesh(uniform RayGenData record) {
   Payload payload;
   uint2 pixelID = DispatchRaysIndex().xy;
   uint2 iResolution = DispatchRaysDimensions().xy;
-
+  
   // camera movement
   float an = pc.time;
   
-  float zoom = 100; // Increase the radius over time
-  float3 ro = float3(-zoom * sin(an), 0.0, zoom * cos(an));
-  float3 ta = float3(0.0, 0.0, 0.0);
+  float3 center = pc.scene_center;
+  float radius = pc.camera.radius; // or compute from bounding box size
+  float3 ro = center + float3(-radius * sin(an), 0.0, radius * cos(an));
+  float3 ta = center;
 
   // camera matrix
   float3 ww = normalize(ta - ro);
@@ -145,8 +146,8 @@ void ray_fire_hit(uniform TrianglesGeomData record, inout RayFirePayload payload
     payload.normal = record.normals[PrimitiveIndex()];
 
     // Print the ray's origin and direction
-    printf("Closest Hit called!");
-    printf("Normal returned: (%f, %f, %f)", payload.normal.x, payload.normal.y, payload.normal.z);
+    // printf("Closest Hit called!");
+    // printf("Normal returned: (%f, %f, %f)", payload.normal.x, payload.normal.y, payload.normal.z);
     // printf("Closest Hit called! Distance: %f, surf_id: %u\n", payload.distance, record.id);
     // printf("Ray Origin: (%f, %f, %f)\n", payload.origin.x, payload.origin.y, payload.origin.z);
     // printf("Ray Direction: (%f, %f, %f)\n", payload.direction.x, payload.direction.y, payload.direction.z);
@@ -159,7 +160,7 @@ void ray_fire_miss(inout RayFirePayload payload) {
     payload.distance = -1.0f;
     payload.surf_id = ~0u;
     payload.normal = {0.0, 0.0, 0.0};
-    printf("Miss shader called!\n");
+    // printf("Miss shader called!\n");
 }
 
 // This ray generation program will kick off the ray tracing process,
@@ -193,10 +194,10 @@ void ray_fire(uniform RayGenData record, uniform TrianglesGeomData mesh) {
                    : RAY_FLAG_CULL_BACK_FACING_TRIANGLES;
     
 
-    printf("Distance Limit: %f\n", rayFirePC.dist_limit);
-    printf("Orientation: %u\n", rayFirePC.orientation);
-    printf("TMax before TraceRay: %f\n PC.dist_limit: %f\n", rayDesc.TMax, rayFirePC.dist_limit);
-    printf("Exclude_primitive size: %i \n", record.ray.exclude_count);
+    // printf("Distance Limit: %f\n", rayFirePC.dist_limit);
+    // printf("Orientation: %u\n", rayFirePC.orientation);
+    // printf("TMax before TraceRay: %f\n PC.dist_limit: %f\n", rayDesc.TMax, rayFirePC.dist_limit);
+    // printf("Exclude_primitive size: %i \n", record.ray.exclude_count);
     TraceRay(record.world, rayFlagCull, 0xff, 0, 1, 0, rayDesc, payload);
 
     // Store the distance to the hit point and the surface ID in buffers for CPU
@@ -209,9 +210,9 @@ void point_in_volume(uniform RayGenData record, uniform TrianglesGeomData mesh) 
     RayFirePayload payload;
     uint rayID = DispatchRaysIndex().x;
 
-    printf("Ray Generation Shader called with :");
-    printf("Ray Origin: (%f, %f, %f)\n", record.ray.origin.x, record.ray.origin.y, record.ray.origin.z);
-    printf("Ray Direction: (%f, %f, %f)\n", record.ray.direction.x, record.ray.direction.y, record.ray.direction.z);
+    // printf("Ray Generation Shader called with :");
+    // printf("Ray Origin: (%f, %f, %f)\n", record.ray.origin.x, record.ray.origin.y, record.ray.origin.z);
+    // printf("Ray Direction: (%f, %f, %f)\n", record.ray.direction.x, record.ray.direction.y, record.ray.direction.z);
     // printf("Excluded Primitives.size(): %i \n", record.ray.exclude_count);
 
     // Trace the ray into the scene

--- a/src/gprt/flt_deviceCode.slang
+++ b/src/gprt/flt_deviceCode.slang
@@ -43,6 +43,8 @@ void render_hits(uniform TrianglesGeomData record, inout Payload payload, in flo
         // payload.color = float3(r, g, b);
         payload.color = float3(0.0, 1.0, 0.0);
     }
+
+    // printf("Closest Hit called! Parent Vols: (%u, %u), surf_id: %u\n", record.forward_vol, record.reverse_vol, record.id);
 }
 
 // This ray generation program will kick off the ray tracing process,

--- a/src/gprt/flt_deviceCode.slang
+++ b/src/gprt/flt_deviceCode.slang
@@ -27,7 +27,7 @@ struct RayFirePayload {
 // - The third is the intersection attributes. For triangles, these are two "barycentrics", used
 //   for interpolating per-vertex values.
 [shader("closesthit")]
-void TriangleMesh(uniform TrianglesGeomData record, inout Payload payload, in float2 bc) {
+void render_hits(uniform TrianglesGeomData record, inout Payload payload, in float2 bc) {
     // Threshold to determine edge thickness
     const float edgeThreshold = 0.02;
 
@@ -48,7 +48,7 @@ void TriangleMesh(uniform TrianglesGeomData record, inout Payload payload, in fl
 // This ray generation program will kick off the ray tracing process,
 // generating rays and tracing them into the world.
 [shader("raygeneration")]
-void raygen(uniform RayGenData record) {
+void render_mesh(uniform RayGenData record) {
   Payload payload;
   uint2 pixelID = DispatchRaysIndex().xy;
   uint2 iResolution = DispatchRaysDimensions().xy;
@@ -86,8 +86,8 @@ void raygen(uniform RayGenData record) {
     TraceRay(record.world,     // the tree
               RAY_FLAG_NONE,   // ray flags
               0xff,            // instance inclusion mask
-              0,               // ray type
-              1,               // number of ray types
+              1,               // ray type (set to render ray type)
+              2,               // number of ray types
               0,               // miss index
               rayDesc,         // the ray to trace
               payload          // the payload IO
@@ -104,7 +104,7 @@ void raygen(uniform RayGenData record) {
 }
 
 [shader("miss")]
-void miss(inout Payload payload, inout RayDesc rayDesc) {
+void render_miss(inout Payload payload, inout RayDesc rayDesc) {
     // Set a gradient background based on the ray direction
     float3 dir = normalize(rayDesc.Direction);
     payload.color = float3(1.0, 1.0, 1.0);
@@ -225,7 +225,7 @@ void point_in_volume(uniform RayGenData record, uniform TrianglesGeomData mesh) 
     payload.surf_id = ~0u;   
     payload.tlas = record.world;    
 
-    TraceRay(record.world, RAY_FLAG_NONE, 0xff, 0, 1, 0, rayDesc, payload);
+    TraceRay(record.world, RAY_FLAG_NONE, 0xff, 0, 2, 0, rayDesc, payload);
 
     // Store the distance to the hit point and the surface ID in buffers for CPU
     record.out.surf_id = payload.surf_id;

--- a/src/gprt/flt_deviceCode.slang
+++ b/src/gprt/flt_deviceCode.slang
@@ -89,7 +89,7 @@ void render_mesh(uniform RayGenData record) {
               0xff,            // instance inclusion mask
               1,               // ray type (set to render ray type)
               2,               // number of ray types
-              0,               // miss index
+              1,               // miss index
               rayDesc,         // the ray to trace
               payload          // the payload IO
     );

--- a/src/gprt/flt_deviceCode.slang
+++ b/src/gprt/flt_deviceCode.slang
@@ -140,7 +140,6 @@ void ray_fire_hit(uniform TrianglesGeomData record, inout RayFirePayload payload
     //     "Index of next volume BLAS %i\n", record.id, record.vols[1], record.vols[0], record.ff_vol);
     //   }
     // }
-
  
 
     payload.distance = RayTCurrent();

--- a/src/gprt/ray_tracer.cpp
+++ b/src/gprt/ray_tracer.cpp
@@ -19,7 +19,6 @@ GPRTRayTracer::GPRTRayTracer()
   rayInputBuffer_ = gprtDeviceBufferCreate<dblRayInput>(context_, numRays);
   rayOutputBuffer_ = gprtDeviceBufferCreate<dblRayOutput>(context_, numRays); 
   excludePrimitivesBuffer_ = gprtDeviceBufferCreate<int32_t>(context_); // initialise buffer of size 1
-  dpRaysBuffer_ = gprtDeviceBufferCreate<double4>(context_, numRays * 2); // Double precision rays, 2 per ray
 
   setup_shaders();
 
@@ -99,8 +98,8 @@ TreeID GPRTRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_ma
       geom_data->vertex = gprtBufferGetDevicePointer(vertex_buffer);
       geom_data->index = gprtBufferGetDevicePointer(connectivity_buffer);
       geom_data->aabbs = gprtBufferGetDevicePointer(aabb_buffer);
-      geom_data->id = surf;
       geom_data->ray = gprtBufferGetDevicePointer(rayInputBuffer_);
+      geom_data->out = gprtBufferGetDevicePointer(rayOutputBuffer_);
 
       gprtComputeLaunch(aabbPopulationProgram_, {num_faces, 1, 1}, {1, 1, 1}, *geom_data);
 

--- a/src/gprt/ray_tracer.cpp
+++ b/src/gprt/ray_tracer.cpp
@@ -71,13 +71,13 @@ TreeID GPRTRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_ma
     bool first_visit = !surface_to_geometry_map_.count(surf);
     auto triangleGeom = gprtGeomCreate<DPTriangleGeomData>(context_, trianglesGeomType_);
     gprt::Instance instance;
+    auto num_faces = mesh_manager->num_surface_faces(surf);
 
     std::cout << "  Surface " << surf << (first_visit ? " (first visit)" : " (already registered)") << std::endl;
 
-    if (first_visit)
-    {
+    // if (first_visit)
+    // {
       auto [vertices, indices] = mesh_manager->get_surface_mesh(surf);
-
       std::vector<double3> dbl3Vertices;
       dbl3Vertices.reserve(vertices.size());    
       for (const auto &vertex : vertices) {
@@ -91,8 +91,8 @@ TreeID GPRTRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_ma
       }
 
       auto vertex_buffer = gprtDeviceBufferCreate<double3>(context_, dbl3Vertices.size(), dbl3Vertices.data());
-      auto aabb_buffer = gprtDeviceBufferCreate<float3>(context_, 2*mesh_manager->num_surface_faces(surf), 0); // AABBs for each triangle
-      gprtAABBsSetPositions(triangleGeom, aabb_buffer, mesh_manager->num_surface_faces(surf), 2*sizeof(float3), 0);
+      auto aabb_buffer = gprtDeviceBufferCreate<float3>(context_, 2*num_faces, 0); // AABBs for each triangle
+      gprtAABBsSetPositions(triangleGeom, aabb_buffer, num_faces, 2*sizeof(float3), 0);
       auto connectivity_buffer = gprtDeviceBufferCreate<uint3>(context_, ui3Indices.size(), ui3Indices.data());
       
       DPTriangleGeomData* geom_data = gprtGeomGetParameters(triangleGeom);
@@ -101,7 +101,17 @@ TreeID GPRTRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_ma
       geom_data->aabbs = gprtBufferGetDevicePointer(aabb_buffer);
       geom_data->id = surf;
 
-      gprtComputeLaunch(aabbPopulationProgram_, {1, 1, 1}, {1, 1, 1}, *geom_data);
+      gprtComputeLaunch(aabbPopulationProgram_, {num_faces, 1, 1}, {1, 1, 1}, *geom_data);
+
+      // gprtBufferMap(aabb_buffer);
+      // float3* aabbs_host = gprtBufferGetHostPointer(aabb_buffer);
+      // for (size_t i = 0; i < 2*mesh_manager->num_surface_faces(surf); i += 2) {
+      //   float3 aabb_min = aabbs_host[i];
+      //   float3 aabb_max = aabbs_host[i + 1];
+      //   std::cout << "AABB " << i/2 << ": min(" << aabb_min.x << ", " << aabb_min.y << ", " << aabb_min.z
+      //             << "), max(" << aabb_max.x << ", " << aabb_max.y << ", " << aabb_max.z << ")" << std::endl;
+      // }
+      // gprtBufferUnmap(aabb_buffer);
 
       GPRTAccel blas = gprtAABBAccelCreate(context_, triangleGeom, GPRT_BUILD_MODE_FAST_TRACE_NO_UPDATE);
       gprtAccelBuild(context_, blas, GPRT_BUILD_MODE_FAST_TRACE_NO_UPDATE);
@@ -120,16 +130,16 @@ TreeID GPRTRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_ma
       globalBlasInstances_.push_back(instance);
 
       std::cout << "    globalBlasInstances_ size now: " << globalBlasInstances_.size() << std::endl;
-    }
-    else 
-    {
-      triangleGeom = surface_to_geometry_map_.at(surf);
-      instance = surface_to_instance_map_.at(surf);
-    }
+    // }
+    // else 
+    // {
+    //   triangleGeom = surface_to_geometry_map_.at(surf);
+    //   instance = surface_to_instance_map_.at(surf);
+    // }
     surfaceBlasInstances.push_back(instance);
 
     // Always update per-volume info
-    DPTriangleGeomData* geom_data = gprtGeomGetParameters(triangleGeom);
+    // DPTriangleGeomData* geom_data = gprtGeomGetParameters(triangleGeom);
     auto [forward_parent, reverse_parent] = mesh_manager->get_parent_volumes(surf);
 
     if (volume_id == forward_parent) {

--- a/src/gprt/ray_tracer.cpp
+++ b/src/gprt/ray_tracer.cpp
@@ -67,9 +67,7 @@ TreeID GPRTRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_ma
 
   for (const auto &surf : volume_surfaces) {
     // Get surface mesh vertices and associated connectivities
-    auto meshParams = mesh_manager->get_surface_mesh(surf);
-    auto vertices = meshParams.first;
-    auto indices = meshParams.second;
+    auto [vertices, indices] = mesh_manager->get_surface_mesh(surf);
 
     GPRTBufferOf<float3> vertex_buffer;
     GPRTBufferOf<uint3> connectivity_buffer;
@@ -111,7 +109,8 @@ TreeID GPRTRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_ma
     geom_data->index = gprtBufferGetDevicePointer(connectivity_buffer);
     geom_data->normals = gprtBufferGetDevicePointer(normal_buffer);
     geom_data->id = surf;
-    geom_data->vols = { mesh_manager->get_parent_volumes(surf).first, mesh_manager->get_parent_volumes(surf).second };
+    auto [forward_parent, reverse_parent] = mesh_manager->get_parent_volumes(surf);
+    geom_data->vols = {forward_parent, reverse_parent}; // Store both parent volumes
     geom_data->sense = static_cast<int>(mesh_manager->surface_sense(surf, volume_id)); // 0 for forward, 1 for reverse
 
     // Set vertices and indices for the triangle geometry

--- a/src/gprt/sharedCode.h
+++ b/src/gprt/sharedCode.h
@@ -1,8 +1,9 @@
 #include "gprt.h"
 
 #define AA 3 // used for antialiasing
-
-
+#define EPSILON 2.2204460492503130808472633361816E-16
+// #define FLT_EPSILON	1.19209290e-7F
+// #define DBL_EPSILON	2.2204460492503131e-16
 
 /* Inputs for each ray */
 struct RayInput {
@@ -50,7 +51,7 @@ struct DPTriangleGeomData {
   float3 *aabbs; // AABB buffer 
   uint3 *index;  // index buffer
   double3 *normals; // normals buffer
-  double4 *dprays; // double precision rays
+  dblRayInput *ray; // double precision rays
   uint id;       // surface id
   int forward_vol;
   int reverse_vol;
@@ -61,6 +62,13 @@ struct RayGenData {
   SurfaceAccelerationStructure world;    // The top-level accel structure
   RayInput *ray;
   RayOutput *out;
+};
+
+struct dblRayGenData {
+  uint* frameBuffer;                     // Optional for debugging or visuals
+  SurfaceAccelerationStructure world;    // The top-level accel structure
+  dblRayInput *ray;
+  dblRayOutput *out;
 };
 
 struct RayFireData {

--- a/src/gprt/sharedCode.h
+++ b/src/gprt/sharedCode.h
@@ -17,6 +17,8 @@ struct dblRayInput
 {
   double3 origin;
   double3 direction;
+  double tMin; // Minimum distance for ray intersection
+  double tMax; // Maximum distance for ray intersection
   int32_t* exclude_primitives; // Optional for excluding primitives
   uint32_t exclude_count;           // Number of excluded primitives
 };
@@ -52,7 +54,7 @@ struct DPTriangleGeomData {
   uint3 *index;  // index buffer
   double3 *normals; // normals buffer
   dblRayInput *ray; // double precision rays
-  uint id;       // surface id
+  int2 vols;
   int forward_vol;
   int reverse_vol;
 };

--- a/src/gprt/sharedCode.h
+++ b/src/gprt/sharedCode.h
@@ -61,7 +61,9 @@ struct MissProgData {
   shader binding table. (must be 128 bytes or less) */
 struct PushConstants {
   float time;
+  float3 scene_center;
   struct Camera {
+    float radius;
     float3 pos;
     float3 dir_00;
     float3 dir_du;

--- a/src/gprt/sharedCode.h
+++ b/src/gprt/sharedCode.h
@@ -23,8 +23,8 @@ struct TrianglesGeomData {
   uint3 *index;   // index buffer
   float3 *normals;
   uint id;        // surface id
-  int2 vols;      // parent volumes ids
-  int sense;      // surface sense
+  int forward_vol; 
+  int reverse_vol;
 };
 // /* variables for the triangle mesh geometry */
 // struct DPTriangleGeomData {

--- a/src/gprt/sharedCode.h
+++ b/src/gprt/sharedCode.h
@@ -10,6 +10,14 @@ struct RayInput {
   uint32_t exclude_count;           // Number of excluded primitives
 };
 
+struct dblRayInput 
+{
+  double3 origin;
+  double3 direction;
+  int32_t* exclude_primitives; // Optional for excluding primitives
+  uint32_t exclude_count;           // Number of excluded primitives
+};
+
 struct RayOutput 
 {
   float distance;
@@ -17,7 +25,14 @@ struct RayOutput
   float3 normal;
 };
 
-/* variables for the triangle mesh geometry */
+struct dblRayOutput 
+{
+  double distance;
+  uint surf_id;
+  double3 normal;
+};
+
+/* variables for the single precision triangle mesh geometry */
 struct TrianglesGeomData {
   float3 *vertex; // vertex buffer
   uint3 *index;   // index buffer
@@ -26,15 +41,17 @@ struct TrianglesGeomData {
   int forward_vol; 
   int reverse_vol;
 };
-// /* variables for the triangle mesh geometry */
-// struct DPTriangleGeomData {
-//   double3 *vertex; // vertex buffer
-//   uint3 *index;  // index buffer
-//   double4 *dprays; // double precision rays
-//   uint id;       // surface id
-//   uint2 vols;    // parent volumes
-//   uint fbSize; // framebuffer size
-// };
+
+/* variables for double precision triangle mesh geometry */
+struct DPTriangleGeomData {
+  double3 *vertex; // vertex buffer
+  uint3 *index;  // index buffer
+  double3 *normals; // normals buffer
+  double4 *dprays; // double precision rays
+  uint id;       // surface id
+  int forward_vol;
+  int reverse_vol;
+};
 
 struct RayGenData {
   uint* frameBuffer;                     // Optional for debugging or visuals
@@ -50,6 +67,12 @@ struct RayFireData {
   RayOutput out;
 };
 
+struct dblRayFireData {
+  uint* frameBuffer;                     // Optional for debugging or visuals
+  SurfaceAccelerationStructure world;    // The top-level accel structure
+  dblRayInput ray;
+  dblRayOutput out;
+};
 
 /* variables for the miss program */
 struct MissProgData {
@@ -73,5 +96,10 @@ struct PushConstants {
 
 struct RayFirePushConstants {
   float dist_limit;
+  int orientation;
+};
+
+struct dblRayFirePushConstants {
+  double dist_limit;
   int orientation;
 };

--- a/src/gprt/sharedCode.h
+++ b/src/gprt/sharedCode.h
@@ -2,6 +2,8 @@
 
 #define AA 3 // used for antialiasing
 
+
+
 /* Inputs for each ray */
 struct RayInput {
   float3 origin;
@@ -45,6 +47,7 @@ struct TrianglesGeomData {
 /* variables for double precision triangle mesh geometry */
 struct DPTriangleGeomData {
   double3 *vertex; // vertex buffer
+  float3 *aabbs; // AABB buffer 
   uint3 *index;  // index buffer
   double3 *normals; // normals buffer
   double4 *dprays; // double precision rays

--- a/tests/test_moab.cpp
+++ b/tests/test_moab.cpp
@@ -97,7 +97,6 @@ TEST_CASE("Test Ray Fire MOAB")
   std::pair<double, MeshID> intersection;
 
   intersection = xdg->ray_fire(volume, origin, direction);
-  xdg->closest(volume, origin, dist);
 
   // this cube is 10 cm on a side, so the ray should hit the surface at 5 cm
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));

--- a/tools/gprt/gprt_particle_sim.cpp
+++ b/tools/gprt/gprt_particle_sim.cpp
@@ -85,7 +85,7 @@ sim_data.xdg_ = xdg;
 const auto& mm = xdg->mesh_manager();
 mm->load_file(args.get<std::string>("filename"));
 mm->init();
-mm->parse_metadata();
+// mm->parse_metadata();
 xdg->prepare_raytracer();
 
 auto rti = xdg->ray_tracing_interface();

--- a/tools/gprt/gprt_particle_sim.cpp
+++ b/tools/gprt/gprt_particle_sim.cpp
@@ -91,7 +91,7 @@ xdg->prepare_raytracer();
 auto rti = xdg->ray_tracing_interface();
 rti->init();
 
-bool renderMesh = true;
+bool renderMesh = false;
 // Create a GPRTRayTracer pointer to access render methods
 if (renderMesh)
 {

--- a/tools/gprt/gprt_particle_sim.cpp
+++ b/tools/gprt/gprt_particle_sim.cpp
@@ -85,16 +85,19 @@ sim_data.xdg_ = xdg;
 const auto& mm = xdg->mesh_manager();
 mm->load_file(args.get<std::string>("filename"));
 mm->init();
+mm->parse_metadata();
 xdg->prepare_raytracer();
 
 auto rti = xdg->ray_tracing_interface();
 rti->init();
-Position origin {0.0, 0.0, 0.0};
-double dist = 100.0;
-TreeID tree = rti->trees()[0];
-rti->closest(tree, origin, dist);
 
-std::cout << "Rendering mesh with GPRT..." << std::endl;
+bool renderMesh = true;
+// Create a GPRTRayTracer pointer to access render methods
+if (renderMesh)
+{
+  auto gprt_rti = std::dynamic_pointer_cast<GPRTRayTracer>(rti);
+  gprt_rti->render_mesh(mm);
+}
 
 // update the mean free path
 sim_data.mfp_ = args.get<double>("--mfp");

--- a/tools/gprt/gprt_particle_sim.cpp
+++ b/tools/gprt/gprt_particle_sim.cpp
@@ -94,8 +94,7 @@ double dist = 100.0;
 TreeID tree = rti->trees()[0];
 rti->closest(tree, origin, dist);
 
-std::cout << "std exit statement reached" << std::endl;
-std::exit(1);
+std::cout << "Rendering mesh with GPRT..." << std::endl;
 
 // update the mean free path
 sim_data.mfp_ = args.get<double>("--mfp");

--- a/tools/point_in_volume.cpp
+++ b/tools/point_in_volume.cpp
@@ -14,8 +14,7 @@
 using namespace xdg;
 
 int main(int argc, char** argv) {
-
-  argparse::ArgumentParser args("XDG Point in Volume Tool", "1.0", argparse::default_arguments::help);
+  argparse::ArgumentParser args("XDG Ray Fire Tool", "1.0", argparse::default_arguments::help);
 
   args.add_argument("filename")
     .help("Path to the input file");
@@ -28,13 +27,21 @@ int main(int argc, char** argv) {
     .implicit_value(true)
     .help("List all volumes in the file and exit");
 
-  args.add_argument("-p",  "--position")
+  args.add_argument("-o", "-p", "--origin", "--position")
     .default_value(std::vector<double>{0.0, 0.0, 0.0})
-    .help("Ray origin").scan<'g', double>().nargs(3);
+    .help("Ray origin/position").scan<'g', double>().nargs(3);
 
   args.add_argument("-d", "--direction")
     .default_value(std::vector<double>{0.0, 0.0, 1.0})
     .help("Ray direction").scan<'g', double>().nargs(3);
+
+  args.add_argument("-m", "--mesh-library")
+      .help("Mesh library to use. One of (MOAB, LIBMESH)")
+      .default_value("MOAB");
+
+  args.add_argument("-r", "--rt-library")
+      .help("Ray tracing library to use. One of (EMBREE, GPRT)")
+      .default_value("EMBREE");
 
   try {
     args.parse_args(argc, argv);
@@ -44,14 +51,36 @@ int main(int argc, char** argv) {
     std::cout << args;
     exit(0);
   }
+  
+  std::string mesh_str = args.get<std::string>("--mesh-library");
+  std::string rt_str   = args.get<std::string>("--rt-library");
+
+  MeshLibrary mesh_lib;
+  if (mesh_str == "MOAB")
+    mesh_lib = MeshLibrary::MOAB;
+  else if (mesh_str == "LIBMESH")
+    fatal_error("LibMesh is not currently supported with GPRT");
+    // mesh_lib = MeshLibrary::LIBMESH;
+  else
+    fatal_error("Invalid mesh library '{}' specified", mesh_str);
+
+  RTLibrary rt_lib;
+  if (rt_str == "EMBREE")
+    rt_lib = RTLibrary::EMBREE;
+  else if (rt_str == "GPRT")
+    rt_lib = RTLibrary::GPRT;
+  else
+    fatal_error("Invalid ray tracing library '{}' specified", rt_str);
 
   // create a mesh manager
-  std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
+  std::shared_ptr<XDG> xdg = XDG::create(mesh_lib, rt_lib);
   const auto& mm = xdg->mesh_manager();
   mm->load_file(args.get<std::string>("filename"));
   mm->init();
   mm->parse_metadata();
-  xdg->prepare_raytracer();
+
+  auto rti = xdg->ray_tracing_interface();
+  rti->init();
 
   if (args.get<bool>("--list")) {
     std::cout << "Volumes: " << std::endl;
@@ -64,6 +93,8 @@ int main(int argc, char** argv) {
   MeshID volume = args.get<int>("volume");
   Position position = args.get<std::vector<double>>("--position");
   Direction direction = args.get<std::vector<double>>("--direction");
+
+  xdg->prepare_volume_for_raytracing(volume);
 
   if (xdg->point_in_volume(volume, position, &direction)) {
     std::cout << "Point " << position << " is in Volume " << volume << " (True)" << std::endl;

--- a/tools/ray_fire.cpp
+++ b/tools/ray_fire.cpp
@@ -36,6 +36,14 @@ int main(int argc, char** argv) {
     .default_value(std::vector<double>{0.0, 0.0, 1.0})
     .help("Ray direction").scan<'g', double>().nargs(3);
 
+  args.add_argument("-m", "--mesh-library")
+      .help("Mesh library to use. One of (MOAB, LIBMESH)")
+      .default_value("MOAB");
+
+  args.add_argument("-r", "--rt-library")
+      .help("Ray tracing library to use. One of (EMBREE, GPRT)")
+      .default_value("GPRT");
+
   try {
     args.parse_args(argc, argv);
   }
@@ -44,14 +52,36 @@ int main(int argc, char** argv) {
     std::cout << args;
     exit(0);
   }
+  
+  std::string mesh_str = args.get<std::string>("--mesh-library");
+  std::string rt_str   = args.get<std::string>("--rt-library");
 
+  MeshLibrary mesh_lib;
+  if (mesh_str == "MOAB")
+    mesh_lib = MeshLibrary::MOAB;
+  else if (mesh_str == "LIBMESH")
+    fatal_error("LibMesh is not currently supported with GPRT");
+    // mesh_lib = MeshLibrary::LIBMESH;
+  else
+    fatal_error("Invalid mesh library '{}' specified", mesh_str);
+
+  RTLibrary rt_lib;
+  if (rt_str == "EMBREE")
+    rt_lib = RTLibrary::EMBREE;
+  else if (rt_str == "GPRT")
+    rt_lib = RTLibrary::GPRT;
+  else
+    fatal_error("Invalid ray tracing library '{}' specified", rt_str);
 
   // create a mesh manager
-  std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
+  std::shared_ptr<XDG> xdg = XDG::create(mesh_lib, rt_lib);
   const auto& mm = xdg->mesh_manager();
   mm->load_file(args.get<std::string>("filename"));
   mm->init();
   mm->parse_metadata();
+
+  auto rti = xdg->ray_tracing_interface();
+  rti->init();
 
   if (args.get<bool>("--list")) {
     std::cout << "Volumes: " << std::endl;

--- a/tools/ray_fire.cpp
+++ b/tools/ray_fire.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv) {
 
   args.add_argument("-r", "--rt-library")
       .help("Ray tracing library to use. One of (EMBREE, GPRT)")
-      .default_value("GPRT");
+      .default_value("EMBREE");
 
   try {
     args.parse_args(argc, argv);


### PR DESCRIPTION
This branch is intended to fully commit to a double precision interface for the GPRTRayTracer. All parts of the code that were originally intended for single precision have been replaced with the required double precision equivalents.

This includes:

Switching to geometry made of AABBs rather than triangle primitives
Implementing a custom intersection shader for double precision hits