### PR TITLE
Refactoring gprt tests

### DIFF
--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -1,8 +1,6 @@
 #ifndef _XDG_GPRT_BASE_RAY_TRACING_INTERFACE_H
 #define _XDG_GPRT_BASE_RAY_TRACING_INTERFACE_H
 
-#ifdef XDG_ENABLE_GPRT // wrap the entire class inside this ifdef
-
 #include <memory>
 #include <vector>
 #include <unordered_map>
@@ -17,9 +15,7 @@
 #include "gprt/gprt.h"
 #include "sharedCode.h"
 
-// extern GPRTProgram flt_deviceCode;
 extern GPRTProgram dbl_deviceCode;
-
 namespace xdg {
 
   class GPRTRayTracer : public RayTracer {
@@ -129,7 +125,5 @@ namespace xdg {
     };
 
 } // namespace xdg
-
-#endif // XDG_ENABLE_GPRT
 
 #endif // include guard

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -1,6 +1,8 @@
 #ifndef _XDG_GPRT_BASE_RAY_TRACING_INTERFACE_H
 #define _XDG_GPRT_BASE_RAY_TRACING_INTERFACE_H
 
+#ifdef XDG_ENABLE_GPRT // wrap the entire class inside this ifdef
+
 #include <memory>
 #include <vector>
 #include <unordered_map>
@@ -127,5 +129,7 @@ namespace xdg {
     };
 
 } // namespace xdg
+
+#endif // XDG_ENABLE_GPRT
 
 #endif // include guard

--- a/include/xdg/mesh_managers.h
+++ b/include/xdg/mesh_managers.h
@@ -1,0 +1,8 @@
+// mesh manager concrete implementations
+#ifdef XDG_ENABLE_MOAB
+#include "xdg/moab/mesh_manager.h"
+#endif
+
+#ifdef XDG_ENABLE_LIBMESH
+#include "xdg/libmesh/mesh_manager.h"
+#endif

--- a/include/xdg/ray_tracers.h
+++ b/include/xdg/ray_tracers.h
@@ -1,0 +1,8 @@
+// ray tracing interface concrete implementations
+#ifdef XDG_ENABLE_EMBREE
+#include "xdg/embree/ray_tracer.h"
+#endif
+
+#ifdef XDG_ENABLE_GPRT
+#include "xdg/gprt/ray_tracer.h"
+#endif

--- a/include/xdg/xdg.h
+++ b/include/xdg/xdg.h
@@ -6,8 +6,7 @@
 
 #include "xdg/mesh_manager_interface.h"
 #include "xdg/ray_tracing_interface.h"
-#include "xdg/embree/ray_tracer.h"
-#include "xdg/gprt/ray_tracer.h"
+
 
 namespace xdg {
 
@@ -17,19 +16,7 @@ public:
   // Constructors
   XDG() = default;
 
-  XDG(std::shared_ptr<MeshManager> mesh_manager, RTLibrary ray_tracing_lib = RTLibrary::EMBREE) : mesh_manager_(mesh_manager)
-  {
-    // construct internal raytracer for XDG
-    switch (ray_tracing_lib)
-    {
-    case RTLibrary::EMBREE:
-      set_ray_tracing_interface(std::make_shared<EmbreeRayTracer>());
-      break;
-    case RTLibrary::GPRT:
-      set_ray_tracing_interface(std::make_shared<GPRTRayTracer>());
-    break;
-    }
-  }
+  XDG(std::shared_ptr<MeshManager> mesh_manager, RTLibrary ray_tracing_lib = RTLibrary::EMBREE);
 
   // factory method that allows for specification of a backend mesh library and ray tracer. Default to MOAB + EMBREE
   static std::shared_ptr<XDG> create(MeshLibrary mesh_lib = MeshLibrary::MOAB, RTLibrary ray_tracing_lib = RTLibrary::EMBREE);
@@ -141,7 +128,6 @@ private:
   std::unordered_map<MeshID, TreeID> volume_to_surface_tree_map_;  //<! Map from mesh volume to raytracing tree
   std::unordered_map<MeshID, TreeID> surface_to_tree_map_; //<! Map from mesh surface to embree scnee
   std::unordered_map<MeshID, TreeID> volume_to_point_location_tree_map_; //<! Map from mesh volume to embree point location tree
-  std::unordered_map<MeshID, RTCGeometry> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
   TreeID global_scene_; // TODO: does this need to be in the RayTacer class or the XDG? class
 };
 

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -6,26 +6,13 @@
 #include "xdg/constants.h"
 #include "xdg/geometry/measure.h"
 
-// mesh manager concrete implementations
-#ifdef XDG_ENABLE_MOAB
-#include "xdg/moab/mesh_manager.h"
-#endif
+#include "xdg/mesh_managers.h"
 
-#ifdef XDG_ENABLE_LIBMESH
-#include "xdg/libmesh/mesh_manager.h"
-#endif
+#include "xdg/ray_tracers.h"
 
-// ray tracing interface concrete implementations
-#ifdef XDG_ENABLE_EMBREE
-#include "xdg/embree/ray_tracer.h"
-#endif
-
-#ifdef XDG_ENABLE_GPRT
-#include "xdg/gprt/ray_tracer.h"
-#endif
 namespace xdg {
 
-XDG::XDG(std::shared_ptr<MeshManager> mesh_manager, RTLibrary ray_tracing_lib) 
+XDG::XDG(std::shared_ptr<MeshManager> mesh_manager, RTLibrary ray_tracing_lib)
         : mesh_manager_(mesh_manager)
 {
   switch (ray_tracing_lib) {

--- a/tests/test_moab.cpp
+++ b/tests/test_moab.cpp
@@ -11,9 +11,7 @@
 #include "xdg/error.h"
 #include "xdg/mesh_manager_interface.h"
 #include "xdg/moab/mesh_manager.h"
-#include "xdg/ray_tracers.h"
 #include "xdg/xdg.h"
-
 #include "util.h"
 
 using namespace xdg;

--- a/tests/test_moab.cpp
+++ b/tests/test_moab.cpp
@@ -118,8 +118,8 @@ TEST_CASE("Test Ray Fire MOAB (all built backends)", "[ray_tracer][moab]") {
 
     MeshID volume = mm->volumes()[0];
 
-    Position  origin{0.0, 0.0, 0.0};
-    Direction dir{1.0, 0.0, 0.0};
+    Position origin {0.0, 0.0, 0.0};
+    Direction dir {1.0, 0.0, 0.0};
 
     auto hit = xdg->ray_fire(volume, origin, dir);
     REQUIRE_THAT(hit.first, Catch::Matchers::WithinAbs(5.0, 1e-6));

--- a/tests/test_moab.cpp
+++ b/tests/test_moab.cpp
@@ -11,16 +11,10 @@
 #include "xdg/error.h"
 #include "xdg/mesh_manager_interface.h"
 #include "xdg/moab/mesh_manager.h"
+#include "xdg/ray_tracers.h"
 #include "xdg/xdg.h"
+
 #include "util.h"
-
-#ifdef XDG_ENABLE_EMBREE
-  #include "xdg/embree/ray_tracer.h"
-#endif
-
-#ifdef XDG_ENABLE_GPRT
-  #include "xdg/gprt/ray_tracer.h"
-#endif
 
 using namespace xdg;
 

--- a/tests/test_moab.cpp
+++ b/tests/test_moab.cpp
@@ -13,7 +13,14 @@
 #include "xdg/mesh_manager_interface.h"
 #include "xdg/moab/mesh_manager.h"
 #include "xdg/xdg.h"
-#include "xdg/embree/ray_tracer.h"
+
+#ifdef XDG_ENABLE_EMBREE
+  #include "xdg/embree/ray_tracer.h"
+#endif
+
+#ifdef XDG_ENABLE_GPRT
+  #include "xdg/gprt/ray_tracer.h"
+#endif
 
 using namespace xdg;
 

--- a/tests/test_point_in_volume.cpp
+++ b/tests/test_point_in_volume.cpp
@@ -78,7 +78,7 @@ TEST_CASE("Point-in-volume on MeshMock (per-backend sections)", "[piv][mock]") {
   #endif
 
   auto rti = create_raytracer(rt_backend);
-  DYNAMIC_SECTION(std::string("Backend = ") + RT_LIB_TO_STR.at(rt_backend)) {
+  DYNAMIC_SECTION(std::string("Ray tracer Backend used = ") + RT_LIB_TO_STR.at(rt_backend)) {
     run_point_in_volume_suite(rti);
   }
 }

--- a/tests/test_point_in_volume.cpp
+++ b/tests/test_point_in_volume.cpp
@@ -4,33 +4,10 @@
 // xdg includes
 #include "xdg/constants.h"
 #include "xdg/mesh_manager_interface.h"
-#include "xdg/ray_tracers.h"
-
+#include "util.h"
 #include "mesh_mock.h"
 
 using namespace xdg;
-
-// Factory method to create ray tracer based on which library selected
-static std::shared_ptr<RayTracer> make_raytracer(RTLibrary rt) {
-  switch (rt) {
-    case RTLibrary::EMBREE:
-    #ifdef XDG_ENABLE_EMBREE
-      return std::make_shared<EmbreeRayTracer>();
-    #else
-      SUCCEED("Embree backend not built; skipping.");
-      return {};
-    #endif
-    case RTLibrary::GPRT:
-    #ifdef XDG_ENABLE_GPRT
-      return std::make_shared<GPRTRayTracer>();
-    #else
-      SUCCEED("GPRT backend not built; skipping.");
-      return {};
-    #endif
-  }
-  FAIL("Unknown RT backend enum value");
-  return {};
-}
 
 // Actual code for test suite
 static void run_point_in_volume_suite(const std::shared_ptr<RayTracer>& rti) {
@@ -67,7 +44,7 @@ static void run_point_in_volume_suite(const std::shared_ptr<RayTracer>& rti) {
   // test a point on the positive x boundary
   // and provide a direction
   point = {5.0, 0.0, 0.0};
-  Direction dir{1.0, 0.0, 0.0};
+  Direction dir {1.0, 0.0, 0.0};
   result = rti->point_in_volume(volume_tree, point, &dir);
   REQUIRE(result == true);
 
@@ -92,7 +69,7 @@ TEST_CASE("Point-in-volume on MeshMock (per-backend sections)", "[piv][mock]") {
   const RTLibrary candidates[] = { RTLibrary::EMBREE, RTLibrary::GPRT };
 
   for (RTLibrary rt : candidates) {
-    auto rti = make_raytracer(rt);
+    auto rti = create_raytracer(rt);
     if (!rti) continue; // backend not built → skip
     DYNAMIC_SECTION(std::string("Backend = ") + RT_LIB_TO_STR.at(rt)) {
       run_point_in_volume_suite(rti);

--- a/tests/test_point_in_volume.cpp
+++ b/tests/test_point_in_volume.cpp
@@ -1,5 +1,7 @@
 // for testing
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
 
 // xdg includes
 #include "xdg/constants.h"
@@ -66,13 +68,17 @@ static void run_point_in_volume_suite(const std::shared_ptr<RayTracer>& rti) {
 // ---------- single test, sections per backend --------------------------------
 
 TEST_CASE("Point-in-volume on MeshMock (per-backend sections)", "[piv][mock]") {
-  const RTLibrary candidates[] = { RTLibrary::EMBREE, RTLibrary::GPRT };
+  // Generate a test only for the backends that we compiled with
+  #if defined(XDG_ENABLE_EMBREE) && defined(XDG_ENABLE_GPRT)
+    auto rt_backend = GENERATE(RTLibrary::EMBREE, RTLibrary::GPRT);
+  #elif defined(XDG_ENABLE_EMBREE)
+    auto rt_backend = GENERATE(RTLibrary::EMBREE);
+  #elif defined(XDG_ENABLE_GPRT)
+    auto rt_backend = GENERATE(RTLibrary::GPRT);
+  #endif
 
-  for (RTLibrary rt : candidates) {
-    auto rti = create_raytracer(rt);
-    if (!rti) continue; // backend not built → skip
-    DYNAMIC_SECTION(std::string("Backend = ") + RT_LIB_TO_STR.at(rt)) {
-      run_point_in_volume_suite(rti);
-    }
+  auto rti = create_raytracer(rt_backend);
+  DYNAMIC_SECTION(std::string("Backend = ") + RT_LIB_TO_STR.at(rt_backend)) {
+    run_point_in_volume_suite(rti);
   }
 }

--- a/tests/test_point_in_volume.cpp
+++ b/tests/test_point_in_volume.cpp
@@ -4,15 +4,9 @@
 // xdg includes
 #include "xdg/constants.h"
 #include "xdg/mesh_manager_interface.h"
-#include "mesh_mock.h"
+#include "xdg/ray_tracers.h"
 
-// Backend headers only if built
-#ifdef XDG_ENABLE_EMBREE
-  #include "xdg/embree/ray_tracer.h"
-#endif
-#ifdef XDG_ENABLE_GPRT
-  #include "xdg/gprt/ray_tracer.h"
-#endif
+#include "mesh_mock.h"
 
 using namespace xdg;
 

--- a/tests/test_point_in_volume.cpp
+++ b/tests/test_point_in_volume.cpp
@@ -2,26 +2,56 @@
 #include <catch2/catch_test_macros.hpp>
 
 // xdg includes
+#include "xdg/constants.h"
 #include "xdg/mesh_manager_interface.h"
-#include "xdg/ray_tracing_interface.h"
-#include "xdg/embree/ray_tracer.h"
-#include "xdg/gprt/ray_tracer.h"
 #include "mesh_mock.h"
+
+// Backend headers only if built
+#ifdef XDG_ENABLE_EMBREE
+  #include "xdg/embree/ray_tracer.h"
+#endif
+#ifdef XDG_ENABLE_GPRT
+  #include "xdg/gprt/ray_tracer.h"
+#endif
 
 using namespace xdg;
 
-TEST_CASE("Test Point in Volume Embree-MeshMock")
-{
-  std::shared_ptr<MeshManager> mm = std::make_shared<MeshMock>(false);
-  mm->init(); // this should do nothing, just good practice to call it
+// Factory method to create ray tracer based on which library selected
+static std::shared_ptr<RayTracer> make_raytracer(RTLibrary rt) {
+  switch (rt) {
+    case RTLibrary::EMBREE:
+    #ifdef XDG_ENABLE_EMBREE
+      return std::make_shared<EmbreeRayTracer>();
+    #else
+      SUCCEED("Embree backend not built; skipping.");
+      return {};
+    #endif
+    case RTLibrary::GPRT:
+    #ifdef XDG_ENABLE_GPRT
+      return std::make_shared<GPRTRayTracer>();
+    #else
+      SUCCEED("GPRT backend not built; skipping.");
+      return {};
+    #endif
+  }
+  FAIL("Unknown RT backend enum value");
+  return {};
+}
+
+// Actual code for test suite
+static void run_point_in_volume_suite(const std::shared_ptr<RayTracer>& rti) {
+  REQUIRE(rti);
+
+  // Keep MeshMock usage consistent across backends
+  auto mm = std::make_shared<MeshMock>(false);
+  mm->init();
   REQUIRE(mm->mesh_library() == MeshLibrary::MOCK);
 
-  std::shared_ptr<RayTracer> rti = std::make_shared<EmbreeRayTracer>();
   auto [volume_tree, element_tree] = rti->register_volume(mm, mm->volumes()[0]);
   REQUIRE(volume_tree != ID_NONE);
   REQUIRE(element_tree == ID_NONE);
 
-  Position point {0.0, 0.0, 0.0};
+  Position point{0.0, 0.0, 0.0};
   bool result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == true);
 
@@ -29,89 +59,45 @@ TEST_CASE("Test Point in Volume Embree-MeshMock")
   result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == false);
 
-  // test a point just inside the positive x boundary
-  point = {4.0 - 1e-06, 0.0, 0.0};
+  // just inside +X boundary
+  point = {4.0 - 1e-6, 0.0, 0.0};
   result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == true);
 
-  // test a point just outside on the positive x boundary
-  // no direction
-  point = {5.001, 0.0, 0,0};
+  // just outside +X, no direction
+  point = {5.001, 0.0, 0.0};
   result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == false);
 
-  // test a point on the positive x boundary
-  // and provide a direction
+  // on +X boundary, with outward direction
   point = {5.0, 0.0, 0.0};
-  Direction dir = {1.0, 0.0, 0.0};
+  Direction dir{1.0, 0.0, 0.0};
   result = rti->point_in_volume(volume_tree, point, &dir);
   REQUIRE(result == true);
 
-  // test a point just outside the positive x boundary
-  // and provide a direction
+  // just outside +X, outward direction
   point = {5.1, 0.0, 0.0};
-  dir = {1.0, 0.0, 0.0};
+  dir   = {1.0, 0.0, 0.0};
   result = rti->point_in_volume(volume_tree, point, &dir);
   REQUIRE(result == false);
 
-  // test a point just outside the positive x boundary,
-  // flip the direction
+  // just outside +X, inward direction
   point = {5.1, 0.0, 0.0};
-  dir = {-1.0, 0.0, 0.0};
+  dir   = {-1.0, 0.0, 0.0};
   result = rti->point_in_volume(volume_tree, point, &dir);
   REQUIRE(result == false);
 }
 
-TEST_CASE("Test Point in Volume GPRT-MeshMock")
-{
-  std::shared_ptr<MeshManager> mm = std::make_shared<MeshMock>();
-  mm->init(); // this should do nothing, just good practice to call it
-  REQUIRE(mm->mesh_library() == MeshLibrary::MOCK);
+// ---------- single test, sections per backend --------------------------------
 
-  std::shared_ptr<RayTracer> rti = std::make_shared<GPRTRayTracer>();
-  auto [volume_tree, element_tree] = rti->register_volume(mm, mm->volumes()[0]);
-  REQUIRE(volume_tree != ID_NONE);
-  REQUIRE(element_tree == ID_NONE);
+TEST_CASE("Point-in-volume on MeshMock (per-backend sections)", "[piv][mock]") {
+  const RTLibrary candidates[] = { RTLibrary::EMBREE, RTLibrary::GPRT };
 
-  Position point {0.0, 0.0, 0.0};
-  bool result = rti->point_in_volume(volume_tree, point);
-  REQUIRE(result == true);
-
-  point = {0.0, 0.0, 1000.0};
-  result = rti->point_in_volume(volume_tree, point);
-  REQUIRE(result == false);
-
-  // test a point just inside the positive x boundary
-  point = {4.0 - 1e-06, 0.0, 0.0};
-  result = rti->point_in_volume(volume_tree, point);
-  REQUIRE(result == true);
-
-  // test a point just outside on the positive x boundary
-  // no direction
-  point = {5.001, 0.0, 0,0};
-  result = rti->point_in_volume(volume_tree, point);
-  REQUIRE(result == false);
-
-  // test a point on the positive x boundary
-  // and provide a direction
-  point = {5.0, 0.0, 0.0};
-  Direction dir = {1.0, 0.0, 0.0};
-  result = rti->point_in_volume(volume_tree, point, &dir);
-  REQUIRE(result == true);
-  // TODO - this is failing because we are on the boundary and firing in a direction outside the volume 
-
-
-  // test a point just outside the positive x boundary
-  // and provide a direction
-  point = {5.1, 0.0, 0.0};
-  dir = {1.0, 0.0, 0.0};
-  result = rti->point_in_volume(volume_tree, point, &dir);
-  REQUIRE(result == false);
-
-  // test a point just outside the positive x boundary,
-  // flip the direction
-  point = {5.1, 0.0, 0.0};
-  dir = {-1.0, 0.0, 0.0};
-  result = rti->point_in_volume(volume_tree, point, &dir);
-  REQUIRE(result == false);
+  for (RTLibrary rt : candidates) {
+    auto rti = make_raytracer(rt);
+    if (!rti) continue; // backend not built → skip
+    DYNAMIC_SECTION(std::string("Backend = ") + RT_LIB_TO_STR.at(rt)) {
+      run_point_in_volume_suite(rti);
+    }
+  }
 }

--- a/tests/test_point_in_volume.cpp
+++ b/tests/test_point_in_volume.cpp
@@ -51,7 +51,7 @@ static void run_point_in_volume_suite(const std::shared_ptr<RayTracer>& rti) {
   REQUIRE(volume_tree != ID_NONE);
   REQUIRE(element_tree == ID_NONE);
 
-  Position point{0.0, 0.0, 0.0};
+  Position point {0.0, 0.0, 0.0};
   bool result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == true);
 
@@ -59,31 +59,35 @@ static void run_point_in_volume_suite(const std::shared_ptr<RayTracer>& rti) {
   result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == false);
 
-  // just inside +X boundary
+  // test a point just inside the positive x boundary
   point = {4.0 - 1e-6, 0.0, 0.0};
   result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == true);
 
-  // just outside +X, no direction
+  // test a point just outside on the positive x boundary
+  // no direction
   point = {5.001, 0.0, 0.0};
   result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == false);
 
-  // on +X boundary, with outward direction
+  // test a point on the positive x boundary
+  // and provide a direction
   point = {5.0, 0.0, 0.0};
   Direction dir{1.0, 0.0, 0.0};
   result = rti->point_in_volume(volume_tree, point, &dir);
   REQUIRE(result == true);
 
-  // just outside +X, outward direction
+  // test a point just outside the positive x boundary
+  // and provide a direction
   point = {5.1, 0.0, 0.0};
-  dir   = {1.0, 0.0, 0.0};
+  dir = {1.0, 0.0, 0.0};
   result = rti->point_in_volume(volume_tree, point, &dir);
   REQUIRE(result == false);
 
-  // just outside +X, inward direction
+  // test a point just outside the positive x boundary,
+  // flip the direction
   point = {5.1, 0.0, 0.0};
-  dir   = {-1.0, 0.0, 0.0};
+  dir = {-1.0, 0.0, 0.0};
   result = rti->point_in_volume(volume_tree, point, &dir);
   REQUIRE(result == false);
 }

--- a/tests/test_ray_fire.cpp
+++ b/tests/test_ray_fire.cpp
@@ -1,6 +1,8 @@
 // for testing
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
 
 // xdg includes
 #include "xdg/constants.h"
@@ -97,14 +99,17 @@ static void run_ray_fire_suite(const std::shared_ptr<RayTracer>& rti) {
 // ------- single test, multiple sections (one per built backend) --------------
 
 TEST_CASE("Ray Fire on MeshMock (per-backend sections)", "[rayfire][mock]") {
-  const RTLibrary candidates[] = { RTLibrary::EMBREE, RTLibrary::GPRT };
 
-  for (RTLibrary rt : candidates) {
-    auto rti = create_raytracer(rt);
-    if (!rti) continue; // backend not built → gracefully skip
+  #if defined(XDG_ENABLE_EMBREE) && defined(XDG_ENABLE_GPRT)
+    auto rt_backend = GENERATE(RTLibrary::EMBREE, RTLibrary::GPRT);
+  #elif defined(XDG_ENABLE_EMBREE)
+    auto rt_backend = GENERATE(RTLibrary::EMBREE);
+  #elif defined(XDG_ENABLE_GPRT)
+    auto rt_backend = GENERATE(RTLibrary::GPRT);
+  #endif
 
-    DYNAMIC_SECTION(std::string("Backend = ") + RT_LIB_TO_STR.at(rt)) {
-      run_ray_fire_suite(rti);
-    }
+  auto rti = create_raytracer(rt_backend);
+  DYNAMIC_SECTION(std::string("Backend = ") + RT_LIB_TO_STR.at(rt_backend)) {
+    run_ray_fire_suite(rti);
   }
 }

--- a/tests/test_ray_fire.cpp
+++ b/tests/test_ray_fire.cpp
@@ -109,7 +109,7 @@ TEST_CASE("Ray Fire on MeshMock (per-backend sections)", "[rayfire][mock]") {
   #endif
 
   auto rti = create_raytracer(rt_backend);
-  DYNAMIC_SECTION(std::string("Backend = ") + RT_LIB_TO_STR.at(rt_backend)) {
+  DYNAMIC_SECTION(std::string("Ray tracer Backend used  = ") + RT_LIB_TO_STR.at(rt_backend)) {
     run_ray_fire_suite(rti);
   }
 }

--- a/tests/test_ray_fire.cpp
+++ b/tests/test_ray_fire.cpp
@@ -52,20 +52,17 @@ static void run_ray_fire_suite(const std::shared_ptr<RayTracer>& rti) {
   REQUIRE(volume_tree != ID_NONE);
   REQUIRE(element_tree == ID_NONE);
 
-  Position origin{0.0, 0.0, 0.0};
-  Direction direction{1.0, 0.0, 0.0};
+  Position origin {0.0, 0.0, 0.0};
+  Direction direction {1.0, 0.0, 0.0};
   std::pair<double, MeshID> intersection;
 
-  // origin → +x
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));
 
-  // origin → -x
   direction *= -1;
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(2.0, 1e-6));
 
-  // origin → ±y
   direction = {0.0, 1.0, 0.0};
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(6.0, 1e-6));
@@ -73,7 +70,6 @@ static void run_ray_fire_suite(const std::shared_ptr<RayTracer>& rti) {
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(3.0, 1e-6));
 
-  // origin → ±z
   direction = {0.0, 0.0, 1.0};
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(7.0, 1e-6));
@@ -81,7 +77,8 @@ static void run_ray_fire_suite(const std::shared_ptr<RayTracer>& rti) {
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(4.0, 1e-6));
 
-  // outside, skip entering (far exit)
+  // fire from the outside of the cube toward each face, ensuring that the intersection distances are correct
+  // rays should skip entering intersections and intersect with the far side of the cube
   origin = {-10.0, 0.0, 0.0};
   direction = {1.0, 0.0, 0.0};
   intersection = rti->ray_fire(volume_tree, origin, direction);
@@ -92,7 +89,8 @@ static void run_ray_fire_suite(const std::shared_ptr<RayTracer>& rti) {
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(12.0, 1e-6));
 
-  // outside, count entering
+  // fire from the outside of the cube toward each face, ensuring that the intersection distances are correct
+  // in this case rays are fired with a HitOrientation::ENTERING. Rays should hit the first surface intersected
   origin = {-10.0, 0.0, 0.0};
   direction = {1.0, 0.0, 0.0};
   intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, HitOrientation::ENTERING);
@@ -103,7 +101,8 @@ static void run_ray_fire_suite(const std::shared_ptr<RayTracer>& rti) {
   intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, HitOrientation::ENTERING);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));
 
-  // distance limit miss / hit
+  // if the distance is just enough, we should still get a hit
+  // limit distance of the ray, shouldn't get a hit
   origin = {0.0, 0.0, 0.0};
   direction = {1.0, 0.0, 0.0};
   intersection = rti->ray_fire(volume_tree, origin, direction, 4.5);
@@ -113,7 +112,9 @@ static void run_ray_fire_suite(const std::shared_ptr<RayTracer>& rti) {
   REQUIRE(intersection.second != ID_NONE);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));
 
-  // exclude primitive then re-fire
+  // Test excluding primitives, fire a ray from the origin and log the hit face
+  // By providing the hit face as an excluded primitive in a subsequent ray fire,
+  // there should be no intersection returned
   std::vector<MeshID> exclude_primitives;
   intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, HitOrientation::EXITING, &exclude_primitives);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));

--- a/tests/test_ray_fire.cpp
+++ b/tests/test_ray_fire.cpp
@@ -5,15 +5,8 @@
 // xdg includes
 #include "xdg/constants.h"
 #include "xdg/mesh_manager_interface.h"
+#include "xdg/ray_tracers.h"
 #include "mesh_mock.h"
-
-// Backend headers only if built
-#ifdef XDG_ENABLE_EMBREE
-  #include "xdg/embree/ray_tracer.h"
-#endif
-#ifdef XDG_ENABLE_GPRT
-  #include "xdg/gprt/ray_tracer.h"
-#endif
 
 using namespace xdg;
 

--- a/tests/util.h
+++ b/tests/util.h
@@ -1,7 +1,9 @@
 #include <random>
 
-#include "xdg/constants.h"
 #include <catch2/catch_test_macros.hpp>
+
+#include "xdg/constants.h"
+#include "xdg/ray_tracers.h"
 
 static std::random_device rd;
 static std::mt19937 gen(rd());
@@ -24,4 +26,26 @@ inline void check_ray_tracer_supported(xdg::RTLibrary rt) {
     SKIP("GPRT backend not built; skipping.");
   }
   #endif
+}
+
+// Factory method to create ray tracer based on which library selected
+inline std::shared_ptr<xdg::RayTracer> create_raytracer(xdg::RTLibrary rt) {
+  switch (rt) {
+    case xdg::RTLibrary::EMBREE:
+    #ifdef XDG_ENABLE_EMBREE
+      return std::make_shared<xdg::EmbreeRayTracer>();
+    #else
+      SKIP("Embree backend not built; skipping.");
+      return {};
+    #endif
+    case xdg::RTLibrary::GPRT:
+    #ifdef XDG_ENABLE_GPRT
+      return std::make_shared<xdg::GPRTRayTracer>();
+    #else
+      SKIP("GPRT backend not built; skipping.");
+      return {};
+    #endif
+  }
+  FAIL("Unknown RT backend enum value");
+  return {};
 }

--- a/tests/util.h
+++ b/tests/util.h
@@ -30,22 +30,14 @@ inline void check_ray_tracer_supported(xdg::RTLibrary rt) {
 
 // Factory method to create ray tracer based on which library selected
 inline std::shared_ptr<xdg::RayTracer> create_raytracer(xdg::RTLibrary rt) {
-  switch (rt) {
-    case xdg::RTLibrary::EMBREE:
-    #ifdef XDG_ENABLE_EMBREE
-      return std::make_shared<xdg::EmbreeRayTracer>();
-    #else
-      SKIP("Embree backend not built; skipping.");
-      return {};
-    #endif
-    case xdg::RTLibrary::GPRT:
-    #ifdef XDG_ENABLE_GPRT
-      return std::make_shared<xdg::GPRTRayTracer>();
-    #else
-      SKIP("GPRT backend not built; skipping.");
-      return {};
-    #endif
-  }
-  FAIL("Unknown RT backend enum value");
-  return {};
+
+  #ifdef XDG_ENABLE_EMBREE
+  if (rt == xdg::RTLibrary::EMBREE) 
+    return std::make_shared<xdg::EmbreeRayTracer>();
+  #endif
+
+  #ifdef XDG_ENABLE_GPRT
+  if (rt == xdg::RTLibrary::GPRT) 
+    return std::make_shared<xdg::GPRTRayTracer>();
+  #endif
 }

--- a/tests/util.h
+++ b/tests/util.h
@@ -1,5 +1,8 @@
 #include <random>
 
+#include "xdg/constants.h"
+#include <catch2/catch_test_macros.hpp>
+
 static std::random_device rd;
 static std::mt19937 gen(rd());
 
@@ -9,3 +12,16 @@ inline double rand_double(double min, double max)
   return dis(gen);
 }
 
+inline void check_ray_tracer_supported(xdg::RTLibrary rt) {
+  #ifndef XDG_ENABLE_EMBREE
+  if (rt == xdg::RTLibrary::EMBREE) {
+    SKIP("Embree backend not built; skipping.");
+  }
+  #endif
+
+  #ifndef XDG_ENABLE_GPRT
+  if (rt == xdg::RTLibrary::GPRT) {
+    SKIP("GPRT backend not built; skipping.");
+  }
+  #endif
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,7 +10,11 @@ foreach(tool ${TOOL_NAMES})
     string(REPLACE "_" "-" tool_exec ${tool})
     add_executable(${tool_exec} ${tool}.cpp)
     target_link_libraries(${tool_exec} xdg argparse indicators::indicators)
-    target_link_libraries(${tool_exec} xdg gprt)
+    
+    if (XDG_ENABLE_GPRT)
+        target_link_libraries(${tool_exec} PRIVATE gprt)
+    endif()
+    
     install(TARGETS ${tool_exec} DESTINATION ${CMAKE_INSTALL_BINDIR}/tools)
 endforeach()
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -12,7 +12,7 @@ foreach(tool ${TOOL_NAMES})
     target_link_libraries(${tool_exec} xdg argparse indicators::indicators)
     
     if (XDG_ENABLE_GPRT)
-        target_link_libraries(${tool_exec} PRIVATE gprt)
+        target_link_libraries(${tool_exec} gprt)
     endif()
     
     install(TARGETS ${tool_exec} DESTINATION ${CMAKE_INSTALL_BINDIR}/tools)


### PR DESCRIPTION
This is a minor PR intended to be merged into the GPRT feature branch that I have been working on. 

I have refactored the tests added with the GPRT branch to avoid code duplication but also put in place some more robust guarding for when GPRT is not enabled with XDG. 

As it currently stands, the GPRT branch will fail to compile with GPRT is not enabled. This PR will ensure that the library compiles and all of the tests also compile. 

Both `test_ray_fire.cpp` and `test_point_in_volume.cpp` make use of the raw `ray_tracing_interface` outside of an xdg instance  so I have ended up implementing a factory method very similar to `xdg::create()` to make things a little bit more flexible in handling the different tests. I don't love this because it feels somewhat redundant, given that we already have pretty much the exact same method already sat within the xdg class. 